### PR TITLE
feat(app): support external quantlab provider controls and tools

### DIFF
--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -315,6 +315,28 @@ func (c *StepbitCoreClient) GetMCPProviders(ctx context.Context) ([]map[string]i
 	return result.Providers, nil
 }
 
+func (c *StepbitCoreClient) UpdateMCPProviderState(ctx context.Context, name string, enabled bool) (map[string]interface{}, error) {
+	resp, err := c.DoAuthenticatedRequest(ctx, http.MethodPost, fmt.Sprintf("/v1/mcp/providers/%s/state", name), map[string]interface{}{
+		"enabled": enabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("mcp provider state update failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // ExecuteReasoning executes a reasoning graph synchronously
 func (c *StepbitCoreClient) ExecuteReasoning(ctx context.Context, graph interface{}) (map[string]interface{}, error) {
 	// Try the current core path first.

--- a/internal/llm/handlers/llm_handler.go
+++ b/internal/llm/handlers/llm_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"io"
@@ -39,6 +40,27 @@ func (h *LlmHandler) ListMCPProviders(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(providers)
+}
+
+func (h *LlmHandler) UpdateMCPProviderState(c *fiber.Ctx) error {
+	provider := strings.TrimSpace(c.Params("provider"))
+	if provider == "" || !providerNamePattern.MatchString(provider) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid provider name"})
+	}
+
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	result, err := h.llmService.UpdateMCPProviderState(c.Context(), provider, req.Enabled)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.JSON(result)
 }
 
 func (h *LlmHandler) GetMCPProviderDoc(c *fiber.Ctx) error {
@@ -285,6 +307,7 @@ func isAllowedArtifactPath(path string) bool {
 func allowedArtifactRoots() []string {
 	roots := []string{
 		filepath.Join(os.TempDir(), "stepbit-core", "quantlab"),
+		filepath.Join(os.TempDir(), "stepbit-core", "quantlab-external"),
 	}
 
 	if cwd, err := os.Getwd(); err == nil {
@@ -305,27 +328,71 @@ func allowedArtifactRoots() []string {
 }
 
 func resolveProviderDocPath(provider string) (string, error) {
-	candidates := make([]string, 0, 4)
+	candidates := make([]string, 0, 3)
 	if coreRoot := os.Getenv("STEPBIT_CORE_ROOT"); coreRoot != "" {
-		candidates = append(candidates, filepath.Join(coreRoot, "src", "mcp", provider, "README.md"))
+		candidates = append(candidates, coreRoot)
 	}
 
 	if cwd, err := os.Getwd(); err == nil {
 		candidates = append(candidates,
-			filepath.Join(cwd, "stepbit-core", "src", "mcp", provider, "README.md"),
-			filepath.Join(cwd, "..", "stepbit-core", "src", "mcp", provider, "README.md"),
+			filepath.Join(cwd, "stepbit-core"),
+			filepath.Join(cwd, "..", "stepbit-core"),
 		)
 	}
 
-	for _, candidate := range candidates {
-		abs, err := filepath.Abs(candidate)
+	for _, root := range candidates {
+		absRoot, err := filepath.Abs(root)
 		if err != nil {
 			continue
 		}
-		if info, statErr := os.Stat(abs); statErr == nil && !info.IsDir() {
-			return abs, nil
+
+		nativeDoc := filepath.Join(absRoot, "src", "mcp", provider, "README.md")
+		if info, statErr := os.Stat(nativeDoc); statErr == nil && !info.IsDir() {
+			return nativeDoc, nil
+		}
+
+		if externalDoc, ok := resolveExternalProviderDocPath(absRoot, provider); ok {
+			return externalDoc, nil
 		}
 	}
 
 	return "", fmt.Errorf("provider documentation not found for %s", provider)
+}
+
+func resolveExternalProviderDocPath(coreRoot, provider string) (string, bool) {
+	pluginRoot := filepath.Join(coreRoot, "plugins", "installed")
+	entries, err := os.ReadDir(pluginRoot)
+	if err != nil {
+		return "", false
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pluginDir := filepath.Join(pluginRoot, entry.Name())
+		manifestPath := filepath.Join(pluginDir, "plugin.json")
+		content, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue
+		}
+
+		var manifest struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			continue
+		}
+		if strings.TrimSpace(strings.ToLower(manifest.Name)) != strings.TrimSpace(strings.ToLower(provider)) {
+			continue
+		}
+
+		readmePath := filepath.Join(pluginDir, "README.md")
+		if info, statErr := os.Stat(readmePath); statErr == nil && !info.IsDir() {
+			return readmePath, true
+		}
+	}
+
+	return "", false
 }

--- a/internal/llm/routes.go
+++ b/internal/llm/routes.go
@@ -32,6 +32,7 @@ func (m *LlmModule) RegisterRoutes(app *fiber.App) {
 	llm := api.Group("/llm")
 	llm.Get("/mcp/tools", m.LlmHandler.ListMCPTools)
 	llm.Get("/mcp/providers", m.LlmHandler.ListMCPProviders)
+	llm.Post("/mcp/providers/:provider/state", m.LlmHandler.UpdateMCPProviderState)
 	llm.Get("/mcp/providers/:provider/doc", m.LlmHandler.GetMCPProviderDoc)
 	llm.Get("/core/health", m.LlmHandler.GetCoreHealthReport)
 	llm.Get("/core/readiness", m.LlmHandler.GetCoreReadinessReport)

--- a/internal/llm/services/llm_service.go
+++ b/internal/llm/services/llm_service.go
@@ -22,6 +22,10 @@ func (s *LlmService) GetMCPProviders(ctx context.Context) (interface{}, error) {
 	return s.coreClient.GetMCPProviders(ctx)
 }
 
+func (s *LlmService) UpdateMCPProviderState(ctx context.Context, name string, enabled bool) (interface{}, error) {
+	return s.coreClient.UpdateMCPProviderState(ctx, name, enabled)
+}
+
 func (s *LlmService) GetCoreHealthReport(ctx context.Context) (core.CoreHealthReport, error) {
 	return s.coreClient.GetHealthReport(ctx)
 }

--- a/web/src/api/llm.ts
+++ b/web/src/api/llm.ts
@@ -17,6 +17,11 @@ export const getMcpProviders = async (): Promise<McpProviderStatus[]> => {
   return response.data;
 };
 
+export const updateMcpProviderState = async (provider: string, enabled: boolean): Promise<McpProviderStatus> => {
+  const response = await api.post(`llm/mcp/providers/${provider}/state`, { enabled });
+  return response.data;
+};
+
 export const fetchMcpProviderDoc = async (provider: string): Promise<string> => {
   const response = await api.get(`llm/mcp/providers/${provider}/doc`, {
     responseType: 'text',

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -84,6 +84,7 @@ vi.mock('../api/llm', () => ({
     Promise.resolve([
       {
         name: 'duckdb',
+        provider_type: 'native',
         enabled: true,
         status: 'installed',
         reason: null,
@@ -93,12 +94,13 @@ vi.mock('../api/llm', () => ({
       },
       {
         name: 'quantlab',
+        provider_type: 'external',
         enabled: true,
         status: 'installed',
         reason: null,
-        capabilities: ['quant-research', 'artifact-generation'],
-        installed_tools: ['quantlab_run'],
-        planned_tools: ['quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
+        capabilities: ['quant-research', 'artifact-generation', 'command:run', 'command:sweep', 'command:forward', 'command:portfolio'],
+        installed_tools: ['quantlab_run', 'quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
+        planned_tools: [],
       },
     ]),
   ),
@@ -149,8 +151,8 @@ describe('Dashboard Page', () => {
     expect(await screen.findByText('Control Plane')).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Open System View' })).toBeInTheDocument();
     expect(await screen.findByText('quantlab')).toBeInTheDocument();
-    expect(await screen.findByText('3 planned')).toBeInTheDocument();
     expect(await screen.findByText('quantlab_sweep')).toBeInTheDocument();
+    expect(await screen.findByText('0 planned')).toBeInTheDocument();
     expect(screen.getByText('Latest Failure')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open Execution History' })).toBeInTheDocument();
   });

--- a/web/src/pages/McpTools.test.tsx
+++ b/web/src/pages/McpTools.test.tsx
@@ -10,12 +10,13 @@ vi.mock('../api/llm', () => ({
     Promise.resolve([
       {
         name: 'quantlab',
+        provider_type: 'external',
         enabled: true,
         status: 'installed',
         reason: null,
-        capabilities: ['quant-research'],
-        installed_tools: ['quantlab_run'],
-        planned_tools: ['quantlab_sweep'],
+        capabilities: ['quant-research', 'command:run', 'command:sweep'],
+        installed_tools: ['quantlab_run', 'quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
+        planned_tools: [],
       },
     ]),
   ),
@@ -29,10 +30,5 @@ describe('McpTools Page', () => {
     expect(screen.getByText('desc')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open System View' })).toBeInTheDocument();
     expect(screen.getByText('MCP Tool Playground')).toBeInTheDocument();
-    expect(screen.getByText('Planned Tool Surface')).toBeInTheDocument();
-    expect(screen.getByText('quantlab • quantlab_sweep')).toBeInTheDocument();
-    expect(screen.getByText('Planned Tool Details')).toBeInTheDocument();
-    expect(await screen.findAllByText('Provider Guide')).not.toHaveLength(0);
-    expect(await screen.findByText('Planned provider docs.')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/McpTools.tsx
+++ b/web/src/pages/McpTools.tsx
@@ -750,6 +750,48 @@ const buildGuidedDefaults = (tool: McpTool) => {
       run_label: 'Demo ETH baseline',
     };
   }
+  if (tool.name === 'quantlab_sweep') {
+    return {
+      strategy: 'rsi_ma_cross_v2',
+      date_range: JSON.stringify({ start: '2023-01-01', end: '2023-12-31' }, null, 2),
+      features: JSON.stringify({ ticker: 'ETH-USD', interval: '1d', fee: 0.002, initial_cash: 1000 }, null, 2),
+      parameters: JSON.stringify({ cooldown_days: 0 }, null, 2),
+      parameter_sets: JSON.stringify([
+        { label: 'baseline', parameters: { rsi_buy_max: 60, rsi_sell_min: 75 } },
+        { label: 'tighter', parameters: { rsi_buy_max: 58, rsi_sell_min: 74 } },
+      ], null, 2),
+      objective: 'total_return',
+      timeout_seconds: '180',
+      run_label: 'ETH sweep',
+    };
+  }
+  if (tool.name === 'quantlab_forward') {
+    return {
+      strategy: 'rsi_ma_cross_v2',
+      features: JSON.stringify({ ticker: 'ETH-USD', interval: '1d', fee: 0.002, initial_cash: 1000 }, null, 2),
+      parameters: JSON.stringify({ rsi_buy_max: 60, rsi_sell_min: 75 }, null, 2),
+      segments: JSON.stringify([
+        { label: 'train-2023h1', start: '2023-01-01', end: '2023-06-30' },
+        { label: 'eval-2023h2', start: '2023-07-01', end: '2023-12-31' },
+      ], null, 2),
+      timeout_seconds: '180',
+      run_label: 'ETH forward',
+    };
+  }
+  if (tool.name === 'quantlab_portfolio') {
+    return {
+      strategy: 'rsi_ma_cross_v2',
+      date_range: JSON.stringify({ start: '2023-01-01', end: '2023-12-31' }, null, 2),
+      features: JSON.stringify({ interval: '1d', fee: 0.002, initial_cash: 1000 }, null, 2),
+      parameters: JSON.stringify({ rsi_buy_max: 60, rsi_sell_min: 75 }, null, 2),
+      legs: JSON.stringify([
+        { label: 'btc', ticker: 'BTC-USD', weight: 0.6 },
+        { label: 'eth', ticker: 'ETH-USD', weight: 0.4 },
+      ], null, 2),
+      timeout_seconds: '180',
+      run_label: 'Crypto basket',
+    };
+  }
 
   const properties = tool.input_schema?.properties || {};
   const defaults: Record<string, string> = {};
@@ -858,6 +900,54 @@ const buildExamples = (tool: McpTool | null) => {
         },
         timeout_seconds: 180,
         run_label: 'Demo BTC baseline',
+      },
+    ];
+  }
+  if (tool.name === 'quantlab_sweep') {
+    return [
+      {
+        strategy: 'rsi_ma_cross_v2',
+        date_range: { start: '2023-01-01', end: '2023-12-31' },
+        features: { ticker: 'ETH-USD', interval: '1d', fee: 0.002, initial_cash: 1000 },
+        parameters: { cooldown_days: 0 },
+        parameter_sets: [
+          { label: 'baseline', parameters: { rsi_buy_max: 60, rsi_sell_min: 75 } },
+          { label: 'tighter', parameters: { rsi_buy_max: 58, rsi_sell_min: 74 } },
+        ],
+        objective: 'total_return',
+        timeout_seconds: 180,
+        run_label: 'ETH sweep',
+      },
+    ];
+  }
+  if (tool.name === 'quantlab_forward') {
+    return [
+      {
+        strategy: 'rsi_ma_cross_v2',
+        features: { ticker: 'ETH-USD', interval: '1d', fee: 0.002, initial_cash: 1000 },
+        parameters: { rsi_buy_max: 60, rsi_sell_min: 75 },
+        segments: [
+          { label: 'train-2023h1', start: '2023-01-01', end: '2023-06-30' },
+          { label: 'eval-2023h2', start: '2023-07-01', end: '2023-12-31' },
+        ],
+        timeout_seconds: 180,
+        run_label: 'ETH forward',
+      },
+    ];
+  }
+  if (tool.name === 'quantlab_portfolio') {
+    return [
+      {
+        strategy: 'rsi_ma_cross_v2',
+        date_range: { start: '2023-01-01', end: '2023-12-31' },
+        features: { interval: '1d', fee: 0.002, initial_cash: 1000 },
+        parameters: { rsi_buy_max: 60, rsi_sell_min: 75 },
+        legs: [
+          { label: 'btc', ticker: 'BTC-USD', weight: 0.6 },
+          { label: 'eth', ticker: 'ETH-USD', weight: 0.4 },
+        ],
+        timeout_seconds: 180,
+        run_label: 'Crypto basket',
       },
     ];
   }

--- a/web/src/pages/System.test.tsx
+++ b/web/src/pages/System.test.tsx
@@ -104,6 +104,7 @@ vi.mock('../api/llm', () => ({
     Promise.resolve([
       {
         name: 'duckdb',
+        provider_type: 'native',
         enabled: true,
         status: 'installed',
         reason: null,
@@ -113,12 +114,13 @@ vi.mock('../api/llm', () => ({
       },
       {
         name: 'quantlab',
+        provider_type: 'external',
         enabled: true,
         status: 'installed',
         reason: null,
-        capabilities: ['quant-research', 'multi-tool-surface'],
-        installed_tools: ['quantlab_run'],
-        planned_tools: ['quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
+        capabilities: ['quant-research', 'multi-tool-surface', 'command:run', 'command:sweep', 'command:forward', 'command:portfolio'],
+        installed_tools: ['quantlab_run', 'quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
+        planned_tools: [],
       },
     ]),
   ),
@@ -136,10 +138,8 @@ describe('System Page', () => {
     expect(await screen.findByText('Recent Events')).toBeInTheDocument();
     expect(await screen.findByText('file.created')).toBeInTheDocument();
     expect(await screen.findByText('watcher')).toBeInTheDocument();
-    expect((await screen.findAllByText('Planned Tools')).length).toBeGreaterThan(0);
     expect(await screen.findByText('quantlab_sweep')).toBeInTheDocument();
     expect(await screen.findByText('Selected Peripheral')).toBeInTheDocument();
     expect(await screen.findByText('Provider Guide')).toBeInTheDocument();
-    expect(await screen.findByText('Provider-local guide for quantlab.')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Activity, CheckCircle2, Clock3, Cpu, Loader2, PlugZap, ShieldCheck, Siren, Timer } from 'lucide-react';
-import { fetchMcpProviderDoc, getCoreCronStatus, getCoreHealthReport, getCoreReadinessReport, getCoreRecentEvents, getCoreSystemRuntime, getMcpProviders } from '../api/llm';
+import { fetchMcpProviderDoc, getCoreCronStatus, getCoreHealthReport, getCoreReadinessReport, getCoreRecentEvents, getCoreSystemRuntime, getMcpProviders, updateMcpProviderState } from '../api/llm';
 import { pipelinesApi } from '../api/pipelines';
 import type { CoreCheck, CoreRecentEvent, McpProviderStatus, StepbitCoreStatus } from '../types';
 import { cn } from '../utils/cn';
@@ -9,6 +9,7 @@ import { MarkdownContent } from '../components/MarkdownContent';
 
 export function System() {
   const [selectedProviderName, setSelectedProviderName] = useState<string>('');
+  const queryClient = useQueryClient();
   const { data: coreStatus, isLoading: statusLoading } = useQuery({
     queryKey: ['system-core-status'],
     queryFn: () => pipelinesApi.getStepbitCoreStatus(),
@@ -75,6 +76,17 @@ export function System() {
     enabled: Boolean(selectedProvider?.name),
     refetchInterval: 10000,
     retry: false,
+  });
+  const providerStateMutation = useMutation({
+    mutationFn: ({ provider, enabled }: { provider: string; enabled: boolean }) =>
+      updateMcpProviderState(provider, enabled),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['system-mcp-providers'] }),
+        queryClient.invalidateQueries({ queryKey: ['system-core-readiness'] }),
+        queryClient.invalidateQueries({ queryKey: ['system-runtime'] }),
+      ]);
+    },
   });
 
   return (
@@ -268,6 +280,8 @@ export function System() {
                 provider={provider}
                 selected={selectedProvider?.name === provider.name}
                 onSelect={setSelectedProviderName}
+                isMutating={providerStateMutation.isPending && providerStateMutation.variables?.provider === provider.name}
+                onToggleExternal={(enabled) => providerStateMutation.mutate({ provider: provider.name, enabled })}
               />
             ))}
             </div>
@@ -368,10 +382,14 @@ function ProviderTile({
   provider,
   selected,
   onSelect,
+  isMutating,
+  onToggleExternal,
 }: {
   provider: McpProviderStatus;
   selected: boolean;
   onSelect: (name: string) => void;
+  isMutating: boolean;
+  onToggleExternal: (enabled: boolean) => void;
 }) {
   return (
     <button
@@ -389,7 +407,7 @@ function ProviderTile({
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="text-sm font-semibold text-gruv-light-1">{provider.name}</p>
-          <p className="mt-1 text-[11px] text-gruv-light-4">{provider.enabled ? 'enabled' : 'disabled'} • {provider.status}</p>
+          <p className="mt-1 text-[11px] text-gruv-light-4">{provider.provider_type} • {provider.enabled ? 'enabled' : 'disabled'} • {provider.status}</p>
         </div>
         <StatusPill
           label={provider.status}
@@ -402,6 +420,28 @@ function ProviderTile({
           }
         />
       </div>
+
+      {provider.provider_type === 'external' && (
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleExternal(!provider.enabled);
+            }}
+            disabled={isMutating}
+            className={cn(
+              'rounded-xs border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors',
+              provider.enabled
+                ? 'border-monokai-orange/30 bg-monokai-orange/10 text-monokai-orange hover:bg-monokai-orange/15'
+                : 'border-monokai-green/30 bg-monokai-green/10 text-monokai-green hover:bg-monokai-green/15',
+              isMutating && 'cursor-wait opacity-70',
+            )}
+          >
+            {isMutating ? 'Updating…' : provider.enabled ? 'Disable Plugin' : 'Enable Plugin'}
+          </button>
+        </div>
+      )}
 
       {provider.reason && <p className="mt-3 text-xs text-gruv-light-3 whitespace-pre-wrap">{provider.reason}</p>}
 
@@ -444,7 +484,7 @@ function ProviderDetailPanel({
           <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Selected Peripheral</p>
           <h3 className="mt-2 text-base font-semibold text-gruv-light-1">{provider.name}</h3>
           <p className="mt-1 text-xs text-gruv-light-4">
-            {provider.installed_tools.length} installed tool{provider.installed_tools.length === 1 ? '' : 's'} • {(provider.planned_tools?.length ?? 0)} planned
+            {provider.provider_type} • {provider.installed_tools.length} installed tool{provider.installed_tools.length === 1 ? '' : 's'} • {(provider.planned_tools?.length ?? 0)} planned
           </p>
         </div>
         <StatusPill

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -135,6 +135,7 @@ export interface StepbitCoreStatus {
 
 export interface McpProviderStatus {
   name: string;
+  provider_type: 'native' | 'external' | string;
   enabled: boolean;
   status: 'installed' | 'disabled' | 'failed' | string;
   reason?: string | null;


### PR DESCRIPTION
## Summary
- align the UI with QuantLab as an external multi-tool provider
- surface the new QuantLab tools in the MCP playground with guided defaults and examples
- keep provider controls and provider metadata aligned with the external QuantLab runtime
- update dashboard, system, and MCP tests to reflect the installed QuantLab surface

## Validation
- pnpm exec vitest run web/src/pages/System.test.tsx web/src/pages/McpTools.test.tsx web/src/pages/Dashboard.test.tsx
- pnpm exec tsc --noEmit