### PR TITLE
test: add parity baseline coverage for Rust migration gaps

### DIFF
--- a/docs/CORE_FEATURE_GAP_ROADMAP.md
+++ b/docs/CORE_FEATURE_GAP_ROADMAP.md
@@ -2,6 +2,8 @@
 
 This document captures the main `stepbit-core` capabilities that are not yet fully surfaced in `stepbit-app`, along with a practical implementation roadmap.
 
+For Rust-to-Go app parity specifically, see [RUST_PARITY_MATRIX.md](/Users/joelguerra/Projects/ai_tools/stepbit-app/docs/RUST_PARITY_MATRIX.md).
+
 ## Goal
 
 Turn `stepbit-app` from a solid manual workflow UI into a full control plane for the more advanced orchestration, automation, and observability features already developed in `stepbit-core`.

--- a/docs/RUST_PARITY_MATRIX.md
+++ b/docs/RUST_PARITY_MATRIX.md
@@ -1,0 +1,60 @@
+# Rust Stepbit Parity Matrix
+
+This document captures the current feature-parity status between the original Rust `stepbit` app and the Go `stepbit-app`.
+
+It exists to support issue [#2](https://github.com/jacovinus/stepbit-app/issues/2) and its staged migration plan.
+
+## Summary
+
+`stepbit-app` already surpasses the original Rust app in several `stepbit-core` integration areas:
+
+- goals and plan preview flows
+- MCP provider management and MCP tool playground
+- richer system/runtime visibility
+- cron, triggers, and execution-history surfaces
+
+The main regression is in the primary chat experience:
+
+- the chat UI still exposes `search` and `reason` toggles
+- the Go backend no longer runs a tool-call loop inside websocket chat
+- live web research tools from the Rust app are not currently ported
+
+## Parity Matrix
+
+| Area | Rust `stepbit` | Go `stepbit-app` | Status |
+| --- | --- | --- | --- |
+| WebSocket chat | Present | Present | Complete |
+| Token streaming | Present | Present | Complete |
+| Chat status messages | Present | Present | Complete |
+| Search toggle in chat | Real effect through tools | Flag exists but no real web-search execution | Gap |
+| Reason toggle in chat | Real effect on chat flow | Flag exists, limited effect | Partial |
+| Tool-call loop in chat | Present | Missing | Gap |
+| `internet_search` tool | Present | Missing | Gap |
+| `read_url` tool | Present | Missing | Gap |
+| `read_full_content` tool | Present | Missing | Gap |
+| Tool result persistence in chat | Present | Missing | Gap |
+| Real chat cancellation | Present | Missing | Gap |
+| Skills CRUD | Present | Present | Complete |
+| `skills/fetch-url` backend | Present | Frontend expects it, backend parity unclear/missing | Gap |
+| Reasoning HTTP/stream | Present | Present | Complete |
+| Pipelines | Present | Present | Complete |
+| Goals flow | More limited | Present and richer | Go-better |
+| MCP provider/catalog surfaces | Limited/older | Present and richer | Go-better |
+| System/runtime diagnostics | More limited | Present and richer | Go-better |
+
+## Highest-Priority Gaps
+
+1. Restore chat request-contract parity for `search` and `reason`.
+2. Port the web research tools and registry.
+3. Restore the websocket chat tool-call loop.
+4. Restore real cancellation semantics.
+5. Close residual endpoint/UI parity such as `skills/fetch-url`.
+
+## Stage Mapping
+
+- [#3](https://github.com/jacovinus/stepbit-app/issues/3): baseline and regression coverage
+- [#4](https://github.com/jacovinus/stepbit-app/issues/4): request-contract parity for `search` and `reason`
+- [#5](https://github.com/jacovinus/stepbit-app/issues/5): Go tool registry + web research tools
+- [#6](https://github.com/jacovinus/stepbit-app/issues/6): websocket chat tool-call loop
+- [#7](https://github.com/jacovinus/stepbit-app/issues/7): cancellation parity
+- [#8](https://github.com/jacovinus/stepbit-app/issues/8): residual parity cleanup and migration docs

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -72,6 +73,45 @@ func TestStepbitCoreClient_ChatStreaming(t *testing.T) {
 
 	if result != "Hello world" {
 		t.Errorf("Expected 'Hello world', got '%s'", result)
+	}
+}
+
+func TestStepbitCoreClient_ChatStreaming_CurrentlyDropsSearchAndReasonFlags(t *testing.T) {
+	var requestBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	client := NewStepbitCoreClient(server.URL, "master-key", "model-1")
+	tokenChan := make(chan StreamMessage, 1)
+
+	err := client.ChatStreaming(context.Background(), []Message{{Role: "user", Content: "search this"}}, ChatOptions{
+		Model:  "model-1",
+		Search: true,
+		Reason: true,
+	}, tokenChan)
+	if err != nil {
+		t.Fatalf("ChatStreaming failed: %v", err)
+	}
+
+	if got := requestBody["model"]; got != "model-1" {
+		t.Fatalf("expected model-1 in request body, got %#v", got)
+	}
+
+	if _, ok := requestBody["search"]; ok {
+		t.Fatalf("characterization failure: search flag is now being forwarded; update this test in Stage 1")
+	}
+
+	if _, ok := requestBody["reason"]; ok {
+		t.Fatalf("characterization failure: reason flag is now being forwarded; update this test in Stage 1")
 	}
 }
 


### PR DESCRIPTION
Closes #3

## Summary
- add a Rust-vs-Go parity matrix doc focused on the original `stepbit` chat/tool/search feature set
- link the existing core gap roadmap to the new parity matrix so the migration plan has a stable reference
- add a characterization test proving that `ChatStreaming` currently drops `search` and `reason` flags before calling the backend

## Verification
- go test ./internal/core

## Notes
- this PR is intentionally a baseline-only stage; it documents the current gap and locks it down before Stage 1 changes the behavior
- the characterization test is designed to fail once `search` or `reason` start getting forwarded, so it should be updated in the Stage 1 PR