### PR TITLE
fix: forward chat search and reason flags

### DIFF
--- a/docs/RUST_PARITY_MATRIX.md
+++ b/docs/RUST_PARITY_MATRIX.md
@@ -26,8 +26,8 @@ The main regression is in the primary chat experience:
 | WebSocket chat | Present | Present | Complete |
 | Token streaming | Present | Present | Complete |
 | Chat status messages | Present | Present | Complete |
-| Search toggle in chat | Real effect through tools | Flag exists but no real web-search execution | Gap |
-| Reason toggle in chat | Real effect on chat flow | Flag exists, limited effect | Partial |
+| Search toggle in chat | Real effect through tools | Flag forwarded end-to-end, but still no real web-search execution | Partial |
+| Reason toggle in chat | Real effect on chat flow | Flag forwarded end-to-end, deeper chat behavior still limited | Partial |
 | Tool-call loop in chat | Present | Missing | Gap |
 | `internet_search` tool | Present | Missing | Gap |
 | `read_url` tool | Present | Missing | Gap |

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -163,6 +163,12 @@ func (c *StepbitCoreClient) ChatStreaming(ctx context.Context, messages []Messag
 		"messages": messages,
 		"stream":   true,
 	}
+	if options.Search {
+		body["search"] = true
+	}
+	if options.Reason {
+		body["reason"] = true
+	}
 	if options.Temperature > 0 {
 		body["temperature"] = options.Temperature
 	}

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -76,7 +76,7 @@ func TestStepbitCoreClient_ChatStreaming(t *testing.T) {
 	}
 }
 
-func TestStepbitCoreClient_ChatStreaming_CurrentlyDropsSearchAndReasonFlags(t *testing.T) {
+func TestStepbitCoreClient_ChatStreaming_ForwardsSearchAndReasonFlags(t *testing.T) {
 	var requestBody map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -106,12 +106,12 @@ func TestStepbitCoreClient_ChatStreaming_CurrentlyDropsSearchAndReasonFlags(t *t
 		t.Fatalf("expected model-1 in request body, got %#v", got)
 	}
 
-	if _, ok := requestBody["search"]; ok {
-		t.Fatalf("characterization failure: search flag is now being forwarded; update this test in Stage 1")
+	if got := requestBody["search"]; got != true {
+		t.Fatalf("expected search=true in request body, got %#v", got)
 	}
 
-	if _, ok := requestBody["reason"]; ok {
-		t.Fatalf("characterization failure: reason flag is now being forwarded; update this test in Stage 1")
+	if got := requestBody["reason"]; got != true {
+		t.Fatalf("expected reason=true in request body, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #4

## Summary
- forward `search` and `reason` through `StepbitCoreClient.ChatStreaming` so websocket chat requests no longer drop those flags
- update the core client regression test to assert the flags are now present in the outbound request body
- refresh the parity matrix wording to reflect that request-contract parity is restored even though tool execution parity still belongs to later stages

## Verification
- go test ./internal/core

## Notes
- this stage only restores request-contract parity
- real web-search execution still depends on Stage 2 and Stage 3 (`internet_search` / `read_url` tools and the websocket tool-call loop)