### PR TITLE
feat(skill): close residual Rust parity gaps

### DIFF
--- a/docs/CORE_FEATURE_GAP_ROADMAP.md
+++ b/docs/CORE_FEATURE_GAP_ROADMAP.md
@@ -20,6 +20,11 @@ The highest-priority Rust parity work for the chat surface is now split into thr
    - targets `#8`
    - closes `skills/fetch-url` and remaining migration/docs gaps
 
+Status update:
+- chat parity foundation is done
+- chat runtime cancellation parity is done
+- residual parity cleanup closes the remaining Rust-era `skills/fetch-url` gap and finalizes the migration notes
+
 ## Goal
 
 Turn `stepbit-app` from a solid manual workflow UI into a full control plane for the more advanced orchestration, automation, and observability features already developed in `stepbit-core`.

--- a/docs/RUST_PARITY_MATRIX.md
+++ b/docs/RUST_PARITY_MATRIX.md
@@ -15,9 +15,7 @@ It exists to support issue [#2](https://github.com/jacovinus/stepbit-app/issues/
 
 The main regression is in the primary chat experience:
 
-- the chat UI still exposes `search` and `reason` toggles
-- chat cancellation is still not wired through to an active upstream request
-- `skills/fetch-url` parity is still pending on the Go backend
+- the final remaining parity work is mostly residual cleanup and docs alignment
 
 ## Parity Matrix
 
@@ -33,9 +31,9 @@ The main regression is in the primary chat experience:
 | `read_url` tool | Present | Missing | Gap |
 | `read_full_content` tool | Present | Missing | Gap |
 | Tool result persistence in chat | Present | Missing | Gap |
-| Real chat cancellation | Present | Missing | Gap |
+| Real chat cancellation | Present | Present | Complete |
 | Skills CRUD | Present | Present | Complete |
-| `skills/fetch-url` backend | Present | Frontend expects it, backend parity unclear/missing | Gap |
+| `skills/fetch-url` backend | Present | Present | Complete |
 | Reasoning HTTP/stream | Present | Present | Complete |
 | Pipelines | Present | Present | Complete |
 | Goals flow | More limited | Present and richer | Go-better |
@@ -44,9 +42,8 @@ The main regression is in the primary chat experience:
 
 ## Highest-Priority Gaps
 
-1. Restore real cancellation semantics.
-2. Close residual endpoint/UI parity such as `skills/fetch-url`.
-3. Audit the OpenAI-compatible chat proxy for the same agentic tool behavior if we want parity outside the websocket path.
+1. Audit the OpenAI-compatible chat proxy for the same agentic tool behavior if we want parity outside the websocket path.
+2. Keep parity docs current as the Go app grows features beyond the Rust original.
 
 ## Stage Mapping
 
@@ -55,4 +52,4 @@ The main regression is in the primary chat experience:
 - [#5](https://github.com/jacovinus/stepbit-app/issues/5): Go tool registry + web research tools - done in grouped chat parity PR
 - [#6](https://github.com/jacovinus/stepbit-app/issues/6): websocket chat tool-call loop - done in grouped chat parity PR
 - [#7](https://github.com/jacovinus/stepbit-app/issues/7): cancellation parity
-- [#8](https://github.com/jacovinus/stepbit-app/issues/8): residual parity cleanup and migration docs
+- [#8](https://github.com/jacovinus/stepbit-app/issues/8): residual parity cleanup and migration docs - done in final parity PR

--- a/internal/skill/handlers/skill_handler.go
+++ b/internal/skill/handlers/skill_handler.go
@@ -1,9 +1,10 @@
 package handlers
 
 import (
+	"context"
+	"github.com/gofiber/fiber/v2"
 	"stepbit-app/internal/skill/models"
 	"stepbit-app/internal/skill/services"
-	"github.com/gofiber/fiber/v2"
 )
 
 type SkillHandler struct {
@@ -42,7 +43,7 @@ func (h *SkillHandler) CreateSkill(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
-	
+
 	newSkill, _ := h.skillService.GetSkill(id)
 	return c.Status(fiber.StatusCreated).JSON(newSkill)
 }
@@ -66,7 +67,7 @@ func (h *SkillHandler) UpdateSkill(c *fiber.Ctx) error {
 	if err := h.skillService.UpdateSkill(int64(id), req.Name, req.Content, req.Tags, req.SourceURL); err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
-	
+
 	newSkill, _ := h.skillService.GetSkill(int64(id))
 	return c.JSON(newSkill)
 }
@@ -77,4 +78,18 @@ func (h *SkillHandler) DeleteSkill(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *SkillHandler) FetchURL(c *fiber.Ctx) error {
+	var req models.FetchURLRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	skill, err := h.skillService.FetchSkillFromURL(context.Background(), req)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(skill)
 }

--- a/internal/skill/models/models.go
+++ b/internal/skill/models/models.go
@@ -6,13 +6,13 @@ import (
 
 // Skill represents a stored skill (Markdown file)
 type Skill struct {
-	ID        int64      `json:"id"`
-	Name      string     `json:"name"`
-	Content   string     `json:"content"`
-	Tags      string     `json:"tags"`
-	SourceURL *string    `json:"source_url"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt time.Time  `json:"updated_at"`
+	ID        int64     `json:"id"`
+	Name      string    `json:"name"`
+	Content   string    `json:"content"`
+	Tags      string    `json:"tags"`
+	SourceURL *string   `json:"source_url"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type CreateSkillRequest struct {
@@ -27,4 +27,10 @@ type UpdateSkillRequest struct {
 	Content   *string `json:"content"`
 	Tags      *string `json:"tags"`
 	SourceURL *string `json:"source_url"`
+}
+
+type FetchURLRequest struct {
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Tags string `json:"tags"`
 }

--- a/internal/skill/routes.go
+++ b/internal/skill/routes.go
@@ -2,9 +2,9 @@ package skill
 
 import (
 	"database/sql"
+	"github.com/gofiber/fiber/v2"
 	"stepbit-app/internal/skill/handlers"
 	"stepbit-app/internal/skill/services"
-	"github.com/gofiber/fiber/v2"
 )
 
 type SkillModule struct {
@@ -27,6 +27,7 @@ func (m *SkillModule) RegisterRoutes(app *fiber.App) {
 
 	api.Get("/", m.SkillHandler.ListSkills)
 	api.Post("/", m.SkillHandler.CreateSkill)
+	api.Post("/fetch-url", m.SkillHandler.FetchURL)
 	api.Get("/:id", m.SkillHandler.GetSkill)
 	api.Patch("/:id", m.SkillHandler.UpdateSkill)
 	api.Delete("/:id", m.SkillHandler.DeleteSkill)

--- a/internal/skill/services/skill_service.go
+++ b/internal/skill/services/skill_service.go
@@ -1,20 +1,30 @@
 package services
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
+	"html"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"stepbit-app/internal/skill/models"
 	"strings"
 )
 
 type SkillService struct {
-	db *sql.DB
+	db         *sql.DB
+	httpClient *http.Client
 }
 
 func NewSkillService(db *sql.DB) *SkillService {
-	return &SkillService{db: db}
+	return &SkillService{
+		db:         db,
+		httpClient: &http.Client{},
+	}
 }
 
 func (s *SkillService) InsertSkill(skill *models.Skill) (int64, error) {
@@ -88,6 +98,57 @@ func (s *SkillService) DeleteSkill(id int64) error {
 	return err
 }
 
+func (s *SkillService) FetchSkillFromURL(ctx context.Context, req models.FetchURLRequest) (*models.Skill, error) {
+	targetURL := strings.TrimSpace(req.URL)
+	name := strings.TrimSpace(req.Name)
+	if targetURL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("User-Agent", "stepbit-app/1.0")
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch failed with status %d", resp.StatusCode)
+	}
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	content := string(rawBody)
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(strings.ToLower(contentType), "text/html") {
+		content = stripHTMLTags(content)
+	}
+
+	sourceURL := targetURL
+	id, err := s.InsertSkill(&models.Skill{
+		Name:      name,
+		Content:   content,
+		Tags:      req.Tags,
+		SourceURL: &sourceURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetSkill(id)
+}
+
 func (s *SkillService) PreloadSkills(dir string) error {
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -126,4 +187,13 @@ func (s *SkillService) PreloadSkills(dir string) error {
 		}
 	}
 	return nil
+}
+
+func stripHTMLTags(input string) string {
+	tagRe := regexp.MustCompile(`(?s)<[^>]+>`)
+	wsRe := regexp.MustCompile(`\s+`)
+	output := tagRe.ReplaceAllString(input, " ")
+	output = html.UnescapeString(output)
+	output = wsRe.ReplaceAllString(output, " ")
+	return strings.TrimSpace(output)
 }

--- a/internal/skill/services/skill_service_test.go
+++ b/internal/skill/services/skill_service_test.go
@@ -1,6 +1,9 @@
 package services
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"stepbit-app/internal/skill/models"
 	"stepbit-app/internal/storage/duckdb"
@@ -49,7 +52,7 @@ func TestSkillService_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpdateSkill failed: %v", err)
 	}
-	
+
 	updated, _ := service.GetSkill(id)
 	if updated.Content != "# Updated Content" {
 		t.Errorf("Expected updated content, got '%s'", updated.Content)
@@ -106,5 +109,44 @@ func TestSkillService_Preload(t *testing.T) {
 	}
 	if !found {
 		t.Error("Preloaded skill 'hello' not found")
+	}
+}
+
+func TestSkillService_FetchSkillFromURL(t *testing.T) {
+	dbPath := "./test_skill_fetch_url.db"
+	defer os.Remove(dbPath)
+
+	db, err := duckdb.NewConnection(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to connect to duckdb: %v", err)
+	}
+	defer db.Close()
+	duckdb.InitSchema(db)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body><h1>Hello</h1><p>Imported skill</p></body></html>"))
+	}))
+	defer server.Close()
+
+	service := NewSkillService(db)
+	skill, err := service.FetchSkillFromURL(context.Background(), models.FetchURLRequest{
+		URL:  server.URL,
+		Name: "Imported Skill",
+		Tags: "imported,test",
+	})
+	if err != nil {
+		t.Fatalf("FetchSkillFromURL failed: %v", err)
+	}
+
+	if skill.Name != "Imported Skill" {
+		t.Fatalf("unexpected skill name: %s", skill.Name)
+	}
+	if skill.SourceURL == nil || *skill.SourceURL != server.URL {
+		t.Fatalf("unexpected source url: %#v", skill.SourceURL)
+	}
+	if skill.Content == "" || skill.Content == "<html><body><h1>Hello</h1><p>Imported skill</p></body></html>" {
+		t.Fatalf("expected cleaned content, got %q", skill.Content)
 	}
 }


### PR DESCRIPTION
Closes #8

## Summary
- add `POST /api/skills/fetch-url` to the Go backend so the existing frontend import flow works again
- fetch remote content with a small HTML-to-text cleanup step and persist imported skills with `source_url`
- finalize the Rust-to-Go parity docs now that chat parity and cancellation are complete

## Verification
- go test ./internal/skill/services
- go test ./internal/skill/handlers
- go test ./...

## Notes
- this closes the last concrete parity gap we identified from the original Rust app
- the remaining follow-up is optional hardening, like deciding whether the OpenAI-compatible HTTP proxy should also grow the same agentic tool loop as websocket chat