### PR TITLE
fix(chat): normalize malformed streamed tool calls

### DIFF
--- a/internal/core/tool_calls.go
+++ b/internal/core/tool_calls.go
@@ -71,7 +71,8 @@ func ExtractStreamingToolCalls(buffer string) ([]ToolCall, string, bool) {
 						case string:
 							arguments = typed
 						default:
-							if data, err := stdjson.Marshal(typed); err == nil {
+							normalized := normalizeToolArguments(typed)
+							if data, err := stdjson.Marshal(normalized); err == nil {
 								arguments = string(data)
 							}
 						}
@@ -105,4 +106,49 @@ func ExtractStreamingToolCalls(buffer string) ([]ToolCall, string, bool) {
 
 		searchStart = absoluteStart + 1
 	}
+}
+
+func normalizeToolArguments(input any) any {
+	switch typed := input.(type) {
+	case map[string]any:
+		if looksLikeSchemaArguments(typed) {
+			properties, _ := typed["properties"].(map[string]any)
+			normalized := make(map[string]any, len(properties))
+			for key, rawProperty := range properties {
+				if propertyMap, ok := rawProperty.(map[string]any); ok {
+					if value, exists := propertyMap["value"]; exists {
+						normalized[key] = normalizeToolArguments(value)
+						continue
+					}
+					if value, exists := propertyMap["default"]; exists {
+						normalized[key] = normalizeToolArguments(value)
+						continue
+					}
+				}
+			}
+			if len(normalized) > 0 {
+				return normalized
+			}
+		}
+
+		normalized := make(map[string]any, len(typed))
+		for key, value := range typed {
+			normalized[key] = normalizeToolArguments(value)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, 0, len(typed))
+		for _, value := range typed {
+			normalized = append(normalized, normalizeToolArguments(value))
+		}
+		return normalized
+	default:
+		return input
+	}
+}
+
+func looksLikeSchemaArguments(input map[string]any) bool {
+	_, hasType := input["type"]
+	_, hasProperties := input["properties"]
+	return hasType && hasProperties
 }

--- a/internal/core/tool_calls_test.go
+++ b/internal/core/tool_calls_test.go
@@ -45,3 +45,17 @@ func TestExtractStreamingToolCalls_IgnoresIncompleteJSON(t *testing.T) {
 		t.Fatal("expected incomplete JSON to be ignored")
 	}
 }
+
+func TestExtractStreamingToolCalls_NormalizesSchemaLikeArguments(t *testing.T) {
+	text := "I will search.\n[{\"name\":\"internet_search\",\"arguments\":{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\",\"description\":\"Search query\",\"value\":\"current time and date\"}}}}]"
+	toolCalls, _, ok := ExtractStreamingToolCalls(text)
+	if !ok {
+		t.Fatal("expected tool calls to be extracted")
+	}
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(toolCalls))
+	}
+	if toolCalls[0].Function.Arguments != "{\"query\":\"current time and date\"}" {
+		t.Fatalf("unexpected normalized arguments: %s", toolCalls[0].Function.Arguments)
+	}
+}

--- a/internal/session/services/chat_loop.go
+++ b/internal/session/services/chat_loop.go
@@ -111,6 +111,9 @@ func buildToolSystemPrompt(searchEnabled, reasonEnabled bool, definitions []chat
 	if len(definitions) > 0 {
 		builder.WriteString("When a tool is needed, respond with a JSON array of tool calls and nothing else after that array.\n")
 		builder.WriteString("Tool call format: [{\"name\":\"tool_name\",\"arguments\":{...}}]\n")
+		builder.WriteString("The `arguments` object must contain only real values for the tool inputs.\n")
+		builder.WriteString("Do not return JSON Schema fields such as `type`, `properties`, `description`, or `required` inside `arguments`.\n")
+		builder.WriteString("Do not explain the tool call, do not add prose after the JSON array, and do not repeat the raw JSON once the tool result comes back.\n")
 		builder.WriteString("Available tools:\n")
 		for _, definition := range definitions {
 			builder.WriteString(fmt.Sprintf("- %s: %s Parameters: %s\n", definition.Name, definition.Description, definition.Parameters))

--- a/internal/session/services/chat_service_test.go
+++ b/internal/session/services/chat_service_test.go
@@ -55,7 +55,7 @@ func TestBuildToolSystemPrompt_IncludesDefinitions(t *testing.T) {
 	if prompt == "" {
 		t.Fatal("expected prompt to be populated")
 	}
-	if !containsAll(prompt, "Reason step-by-step", "internet_search", "Search the web.") {
+	if !containsAll(prompt, "Reason step-by-step", "internet_search", "Search the web.", "Do not return JSON Schema fields", "Do not explain the tool call") {
 		t.Fatalf("prompt missing expected instructions: %s", prompt)
 	}
 }


### PR DESCRIPTION
## Summary
- normalize schema-like tool arguments such as `{type,properties,value}` into real tool input payloads
- strengthen the websocket tool prompt so the model stops emitting schema fields and prose around tool calls
- add regression tests for malformed streamed tool calls that previously leaked back to the user

## Verification
- go test ./internal/core
- go test ./internal/session/services
- go test ./...

## Context
This fixes the case where the model returned tool-call JSON like an explanation/schema instead of an executable call, causing the chat to echo raw JSON instead of running the search tool.