### PR TITLE
docs(chat): add structured launch readiness and coverage

### DIFF
--- a/docs/FEATURES_GUIDE.md
+++ b/docs/FEATURES_GUIDE.md
@@ -116,6 +116,16 @@ Scheduled Jobs bring recurring automation to the Stepbit UI by proxying the cron
 ## 8. Event Triggers (Reactive Automation) 🔔
 Triggers allow Stepbit to react to incoming events and launch actions automatically through `stepbit-core`.
 
+## Structured Agent Chat
+
+The chat UI now prefers the structured `/v1/responses` path exposed by `stepbit-core`.
+
+- Tool activity is streamed as explicit status/trace events instead of leaking raw tool JSON into the conversation.
+- If the structured endpoint is unavailable, Stepbit automatically falls back to the legacy parser path.
+- Selected skills are treated as compact policy prompts rather than being prepended verbatim to the user's message.
+
+See [Structured Agent Launch](./STRUCTURED_AGENT_LAUNCH.md) for rollout and rollback guidance.
+
 ### 🎯 Tutorial: Creating your first Trigger
 1. Open the **Triggers** tab.
 2. Enter a **Trigger ID** such as `file-processor`.

--- a/docs/STRUCTURED_AGENT_LAUNCH.md
+++ b/docs/STRUCTURED_AGENT_LAUNCH.md
@@ -1,0 +1,47 @@
+# Structured Agent Launch
+
+This document closes the launch-readiness work for the structured agent chat path in `stepbit-app`.
+
+## What Changed
+
+- Chat now prefers the structured `/v1/responses` stream from `stepbit-core`.
+- If the structured endpoint is unavailable, the app falls back to the legacy parser path.
+- Selected chat skills are sent as `skill_ids` and converted into compact policy prompts on the backend instead of being prepended verbatim to the user message.
+
+## Launch Checklist
+
+Before calling the structured path launch-ready:
+
+- `go test ./internal/core ./internal/session/services`
+- `go test ./internal/session/services ./internal/skill/services ./internal/session`
+- `go test ./...`
+- `stepbit-core` is running with `STEPBIT_CORE_STRUCTURED_AGENT_CHAT=true`
+- smoke-test these prompts in the chat UI:
+  - "What time is it now?"
+  - "What time is it in Europe/Madrid right now?"
+  - "Search the latest news about Iran"
+  - a direct URL read request
+
+## Expected Behavior
+
+- No raw tool JSON should leak into the chat UI on the structured path.
+- The user should see statuses such as `Running tool: ...`.
+- Structured completions should persist assistant metadata with `structured=true`.
+- If the core does not expose `/v1/responses`, the chat should continue working through the legacy fallback.
+
+## Rollback
+
+If the structured path regresses:
+
+1. Disable `STEPBIT_CORE_STRUCTURED_AGENT_CHAT` on `stepbit-core`.
+2. Restart the core.
+3. `stepbit-app` will automatically fall back to the legacy streaming parser path.
+
+## Skills Policy Notes
+
+- Skills are now treated as policy/style layers, not pseudo-tool tutorials.
+- The backend extracts:
+  - allowed tools
+  - citation expectations
+  - table/conciseness preferences
+- This reduces the tendency of the model to explain tools instead of using them.

--- a/internal/session/services/chat_service_test.go
+++ b/internal/session/services/chat_service_test.go
@@ -23,10 +23,32 @@ type fakeStreamingChatClient struct {
 	cancelledSessions []string
 	mu                sync.Mutex
 	blockOnStream     bool
+	structuredResult  core.ChatStreamResult
+	structuredErr     error
+	structuredStream  []core.StreamMessage
 }
 
 func (f *fakeStreamingChatClient) ChatStreamingStructured(ctx context.Context, messages []core.Message, options core.ChatOptions, tokenChan chan<- core.StreamMessage) (core.ChatStreamResult, error) {
-	return core.ChatStreamResult{}, core.ErrStructuredResponsesUnavailable
+	_ = messages
+	_ = options
+	if f.blockOnStream {
+		<-ctx.Done()
+		return core.ChatStreamResult{}, ctx.Err()
+	}
+	if f.structuredErr == nil && len(f.structuredStream) == 0 && !f.structuredResult.Structured {
+		return core.ChatStreamResult{}, core.ErrStructuredResponsesUnavailable
+	}
+	for _, message := range f.structuredStream {
+		select {
+		case tokenChan <- message:
+		case <-ctx.Done():
+			return core.ChatStreamResult{}, ctx.Err()
+		}
+	}
+	if f.structuredErr != nil {
+		return core.ChatStreamResult{}, f.structuredErr
+	}
+	return f.structuredResult, nil
 }
 
 func (f *fakeStreamingChatClient) ChatStreamingWithToolCalls(ctx context.Context, messages []core.Message, options core.ChatOptions, tokenChan chan<- core.StreamMessage) (core.ChatStreamResult, error) {
@@ -181,6 +203,88 @@ func TestChatService_CancelActiveRun(t *testing.T) {
 	if chatService.CancelActiveRun(context.Background(), sessionID) {
 		t.Fatal("expected second cancellation to report no active run")
 	}
+}
+
+func TestChatService_UsesStructuredPathWhenAvailable(t *testing.T) {
+	dbPath := "./test_chat_structured.db"
+	defer os.Remove(dbPath)
+
+	db, err := duckdb.NewConnection(dbPath)
+	if err != nil {
+		t.Fatalf("Failed to connect to duckdb: %v", err)
+	}
+	defer db.Close()
+
+	if err := duckdb.InitSchema(db); err != nil {
+		t.Fatalf("Failed to init schema: %v", err)
+	}
+
+	sessionService := NewSessionService(db)
+	sessionID := uuid.New()
+	if err := sessionService.InsertSession(&models.Session{ID: sessionID, Title: "Structured Session"}); err != nil {
+		t.Fatalf("InsertSession failed: %v", err)
+	}
+
+	client := &fakeStreamingChatClient{
+		structuredResult: core.ChatStreamResult{
+			Structured: true,
+			UsedTools:  true,
+			ToolEvents: []string{"internet_search"},
+		},
+		structuredStream: []core.StreamMessage{
+			{Type: "status", Content: "Running tool: internet_search..."},
+			{Type: "chunk", Content: "Latest headlines"},
+		},
+	}
+	configService := configServices.NewConfigService(core.NewStepbitCoreClient("http://localhost:1", "test-key", "model-1"), &configModels.AppConfig{})
+	configService.SetActiveModel("model-1")
+
+	chatService := NewChatService(client, sessionService, nil, configService, &configModels.AppConfig{})
+
+	var writes []models.WsServerMessage
+	chatService.handleWsChatMessage(context.Background(), func(message models.WsServerMessage) {
+		writes = append(writes, message)
+	}, sessionID, models.WsClientMessage{
+		Type:    "message",
+		Content: "search current news",
+	})
+
+	history, err := sessionService.GetMessages(sessionID.String(), 20, 0)
+	if err != nil {
+		t.Fatalf("GetMessages failed: %v", err)
+	}
+	if len(history) < 2 {
+		t.Fatalf("expected at least user and assistant messages, got %d", len(history))
+	}
+	assistant := history[len(history)-1]
+	if assistant.Role != "assistant" {
+		t.Fatalf("expected assistant message, got %s", assistant.Role)
+	}
+	if assistant.Content != "Latest headlines" {
+		t.Fatalf("unexpected assistant content: %q", assistant.Content)
+	}
+	if assistant.Metadata["structured"] != true {
+		t.Fatalf("expected structured metadata, got %#v", assistant.Metadata)
+	}
+
+	if !containsMessage(writes, "done", "") {
+		t.Fatalf("expected done message in websocket writes: %#v", writes)
+	}
+	if !containsMessage(writes, "status", "Running tool: internet_search...") {
+		t.Fatalf("expected structured tool status in websocket writes: %#v", writes)
+	}
+}
+
+func containsMessage(messages []models.WsServerMessage, msgType, content string) bool {
+	for _, message := range messages {
+		if message.Type != msgType {
+			continue
+		}
+		if content == "" || message.Content == content {
+			return true
+		}
+	}
+	return false
 }
 
 func containsAll(input string, fragments ...string) bool {


### PR DESCRIPTION
Closes #16

## Summary
- add launch-readiness documentation for the structured agent chat rollout, including rollout and rollback guidance
- add chat-service coverage for the structured path so we verify assistant persistence and websocket messaging when `/v1/responses` is available
- surface the structured-agent chat behavior in the user-facing features guide

## Verification
- go test ./internal/session/services ./internal/skill/services ./internal/core
- go test ./...

## Notes
- this closes the sprint with explicit launch gates instead of relying on manual memory of what to check
- the new chat-service test complements the structured client tests added in the previous PR