### PR TITLE
feat(system): make capability inventory compact and actionable

### DIFF
--- a/web/src/components/system/CapabilityInventoryPanel.tsx
+++ b/web/src/components/system/CapabilityInventoryPanel.tsx
@@ -1,0 +1,276 @@
+import { Loader2 } from 'lucide-react';
+import { MarkdownContent } from '../MarkdownContent';
+import type { McpProviderStatus } from '../../types';
+import { cn } from '../../utils/cn';
+
+export function CapabilityInventoryPanel({
+  providers,
+  loading,
+  selectedProviderName,
+  onSelect,
+  selectedProviderDoc,
+  selectedProviderDocLoading,
+  isMutatingFor,
+  onToggleExternal,
+}: {
+  providers?: McpProviderStatus[];
+  loading: boolean;
+  selectedProviderName: string;
+  onSelect: (name: string) => void;
+  selectedProviderDoc?: string;
+  selectedProviderDocLoading: boolean;
+  isMutatingFor: (providerName: string) => boolean;
+  onToggleExternal: (providerName: string, enabled: boolean) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="flex justify-center p-8">
+        <Loader2 className="w-5 h-5 animate-spin text-monokai-aqua" />
+      </div>
+    );
+  }
+
+  if (!providers?.length) {
+    return <p className="mt-4 text-xs text-gruv-light-4">No provider data available.</p>;
+  }
+
+  const sortedProviders = [...providers].sort(
+    (left, right) =>
+      providerRank(left) - providerRank(right) || providerTitle(left).localeCompare(providerTitle(right)),
+  );
+  const selectedProvider =
+    sortedProviders.find((provider) => provider.name === selectedProviderName) ??
+    sortedProviders[0];
+
+  const availableNow = sortedProviders.filter((provider) => provider.status === 'installed' && provider.enabled).length;
+  const disabledCount = sortedProviders.filter((provider) => provider.status === 'disabled' || !provider.enabled).length;
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <InventoryBadge label={`${availableNow} available now`} tone="green" />
+        <InventoryBadge label={`${disabledCount} disabled`} tone="slate" />
+        <InventoryBadge label={`${sortedProviders.length} total providers`} tone="aqua" />
+      </div>
+
+      <div className="rounded-xs border border-white/10 overflow-hidden">
+        {sortedProviders.map((provider, index) => (
+          <ProviderRow
+            key={provider.name}
+            provider={provider}
+            selected={provider.name === selectedProvider.name}
+            onSelect={onSelect}
+            isMutating={isMutatingFor(provider.name)}
+            onToggleExternal={onToggleExternal}
+            withBorder={index < sortedProviders.length - 1}
+          />
+        ))}
+      </div>
+
+      <ProviderDetails
+        provider={selectedProvider}
+        providerDoc={selectedProviderDoc}
+        providerDocLoading={selectedProviderDocLoading}
+      />
+    </div>
+  );
+}
+
+function ProviderRow({
+  provider,
+  selected,
+  onSelect,
+  isMutating,
+  onToggleExternal,
+  withBorder,
+}: {
+  provider: McpProviderStatus;
+  selected: boolean;
+  onSelect: (name: string) => void;
+  isMutating: boolean;
+  onToggleExternal: (providerName: string, enabled: boolean) => void;
+  withBorder: boolean;
+}) {
+  const topActions = provider.installed_tools.length > 0 ? provider.installed_tools : provider.planned_tools ?? [];
+
+  return (
+    <div
+      className={cn(
+        'p-4 transition-colors',
+        withBorder && 'border-b border-white/10',
+        selected ? 'bg-monokai-aqua/5' : 'bg-transparent',
+      )}
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <button type="button" onClick={() => onSelect(provider.name)} className="min-w-0 text-left">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-semibold text-gruv-light-1">{providerTitle(provider)}</p>
+            <StateBadge status={provider.status} />
+            {provider.scope && <InventoryBadge label={provider.scope} tone="slate" />}
+          </div>
+          <p className="mt-1 text-xs text-gruv-light-3">{provider.summary || providerFallbackSummary(provider)}</p>
+          <p className="mt-2 text-[11px] text-gruv-light-4">
+            {provider.supports_toggle ? 'Managed from the app' : 'Managed from core config'}
+            {provider.activation_key ? ` • key: ${provider.activation_key}` : ''}
+          </p>
+        </button>
+
+        <div className="flex flex-col items-start gap-2 lg:items-end">
+          {provider.supports_toggle ? (
+            <button
+              type="button"
+              onClick={() => onToggleExternal(provider.name, !provider.enabled)}
+              disabled={isMutating}
+              className={cn(
+                'rounded-xs border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors',
+                provider.enabled
+                  ? 'border-monokai-orange/30 bg-monokai-orange/10 text-monokai-orange hover:bg-monokai-orange/15'
+                  : 'border-monokai-green/30 bg-monokai-green/10 text-monokai-green hover:bg-monokai-green/15',
+                isMutating && 'cursor-wait opacity-70',
+              )}
+            >
+              {isMutating ? 'Updating…' : provider.enabled ? 'Disable Plugin' : 'Enable Plugin'}
+            </button>
+          ) : (
+            <InventoryBadge label="config" tone="slate" />
+          )}
+          <div className="flex flex-wrap gap-1.5">
+            {topActions.slice(0, 3).map((tool) => (
+              <InventoryBadge key={tool} label={humanizeIdentifier(tool)} tone="aqua" />
+            ))}
+            {topActions.length > 3 && <InventoryBadge label={`+${topActions.length - 3} more`} tone="slate" />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProviderDetails({
+  provider,
+  providerDoc,
+  providerDocLoading,
+}: {
+  provider: McpProviderStatus;
+  providerDoc?: string;
+  providerDocLoading: boolean;
+}) {
+  return (
+    <div className="rounded-xs border border-monokai-aqua/20 bg-monokai-aqua/5 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Selected capability provider</p>
+          <h3 className="mt-2 text-base font-semibold text-gruv-light-1">{providerTitle(provider)}</h3>
+          <p className="mt-1 text-xs text-gruv-light-3">{provider.summary || providerFallbackSummary(provider)}</p>
+        </div>
+        <StateBadge status={provider.status} />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+        <DetailCard label="How to activate" value={provider.activation_hint || providerFallbackActivation(provider)} />
+        <DetailCard
+          label="Control surface"
+          value={provider.supports_toggle ? 'Stepbit App toggle' : provider.activation_target ?? 'stepbit-core config'}
+        />
+        <DetailCard
+          label="Provider key"
+          value={provider.activation_key ?? provider.name}
+        />
+        <DetailCard
+          label="Available actions"
+          value={(provider.installed_tools.length > 0 ? provider.installed_tools : provider.planned_tools ?? [])
+            .map(humanizeIdentifier)
+            .join(', ') || 'None'}
+        />
+      </div>
+
+      {provider.reason && (
+        <div className="mt-4 rounded-xs border border-monokai-orange/20 bg-monokai-orange/10 p-3">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-monokai-orange">Status detail</p>
+          <p className="mt-2 text-xs text-gruv-light-2 whitespace-pre-wrap">{provider.reason}</p>
+        </div>
+      )}
+
+      <div className="mt-4 rounded-xs border border-white/10 bg-black/10 p-4">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Provider guide</p>
+        {providerDocLoading ? (
+          <div className="flex justify-center p-6">
+            <Loader2 className="w-5 h-5 animate-spin text-monokai-aqua" />
+          </div>
+        ) : providerDoc ? (
+          <div className="mt-3 max-h-[280px] overflow-y-auto pr-2">
+            <MarkdownContent content={providerDoc} />
+          </div>
+        ) : (
+          <p className="mt-4 text-xs text-gruv-light-4">No provider guide available.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DetailCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xs border border-white/10 bg-gruv-dark-4/10 p-3">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">{label}</p>
+      <p className="mt-1.5 text-xs font-semibold break-words text-gruv-light-1">{value}</p>
+    </div>
+  );
+}
+
+function InventoryBadge({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: 'green' | 'slate' | 'aqua';
+}) {
+  const toneClass = {
+    green: 'border-monokai-green/20 bg-monokai-green/15 text-monokai-green',
+    slate: 'border-white/10 bg-white/5 text-gruv-light-3',
+    aqua: 'border-monokai-aqua/20 bg-monokai-aqua/10 text-monokai-aqua',
+  }[tone];
+
+  return <span className={cn('rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', toneClass)}>{label}</span>;
+}
+
+function StateBadge({ status }: { status: string }) {
+  const toneClass =
+    status === 'installed'
+      ? 'border-monokai-green/20 bg-monokai-green/15 text-monokai-green'
+      : status === 'failed'
+        ? 'border-monokai-pink/20 bg-monokai-pink/15 text-monokai-pink'
+        : 'border-white/10 bg-white/5 text-gruv-light-3';
+  return <span className={cn('rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]', toneClass)}>{status}</span>;
+}
+
+function providerRank(provider: McpProviderStatus) {
+  if (provider.status === 'installed' && provider.enabled) return 0;
+  if (provider.supports_toggle) return 1;
+  if (provider.status === 'disabled') return 2;
+  return 3;
+}
+
+function providerTitle(provider: McpProviderStatus) {
+  return provider.title || humanizeIdentifier(provider.name);
+}
+
+function providerFallbackSummary(provider: McpProviderStatus) {
+  return provider.supports_toggle
+    ? 'External plugin exposed through the MCP control plane.'
+    : 'Built-in capability provider managed by stepbit-core.';
+}
+
+function providerFallbackActivation(provider: McpProviderStatus) {
+  return provider.supports_toggle
+    ? 'Use the Enable/Disable Plugin action in the app to change this provider.'
+    : `Add "${provider.name}" to stepbit-core/config/mcp_providers.json and restart stepbit-core.`;
+}
+
+function humanizeIdentifier(value: string) {
+  return value
+    .split(/[_:-]/g)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/web/src/pages/System.test.tsx
+++ b/web/src/pages/System.test.tsx
@@ -104,20 +104,36 @@ vi.mock('../api/llm', () => ({
     Promise.resolve([
       {
         name: 'duckdb',
+        title: 'DuckDB',
+        summary: 'Query local structured data and run SQL over embedded analytics datasets.',
         provider_type: 'native',
+        scope: 'system',
         enabled: true,
         status: 'installed',
         reason: null,
+        activation_kind: 'config',
+        activation_target: 'stepbit-core/config/mcp_providers.json',
+        activation_key: 'duckdb',
+        activation_hint: 'Add "duckdb" to the enabled list and restart stepbit-core.',
+        supports_toggle: false,
         capabilities: ['sql-query'],
         installed_tools: ['duckdb_query'],
         planned_tools: [],
       },
       {
         name: 'quantlab',
+        title: 'QuantLab',
+        summary: 'Run quant research workflows, produce artifacts, and execute market-analysis commands.',
         provider_type: 'external',
+        scope: 'project',
         enabled: true,
         status: 'installed',
         reason: null,
+        activation_kind: 'ui-toggle',
+        activation_target: 'Stepbit App > System',
+        activation_key: null,
+        activation_hint: 'Use the Enable/Disable Plugin action in the app to change this provider.',
+        supports_toggle: true,
         capabilities: ['quant-research', 'multi-tool-surface', 'command:run', 'command:sweep', 'command:forward', 'command:portfolio'],
         installed_tools: ['quantlab_run', 'quantlab_sweep', 'quantlab_forward', 'quantlab_portfolio'],
         planned_tools: [],
@@ -138,8 +154,9 @@ describe('System Page', () => {
     expect(await screen.findByText('Recent Events')).toBeInTheDocument();
     expect(await screen.findByText('file.created')).toBeInTheDocument();
     expect(await screen.findByText('watcher')).toBeInTheDocument();
-    expect(await screen.findByText('quantlab_sweep')).toBeInTheDocument();
-    expect(await screen.findByText('Selected Peripheral')).toBeInTheDocument();
-    expect(await screen.findByText('Provider Guide')).toBeInTheDocument();
+    expect(await screen.findByText('Connected Capabilities')).toBeInTheDocument();
+    expect(await screen.findByText('QuantLab')).toBeInTheDocument();
+    expect(await screen.findByText('How to activate')).toBeInTheDocument();
+    expect(await screen.findByText('Provider guide')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -3,9 +3,9 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Activity, CheckCircle2, Clock3, Cpu, Loader2, PlugZap, ShieldCheck, Siren, Timer } from 'lucide-react';
 import { fetchMcpProviderDoc, getCoreCronStatus, getCoreHealthReport, getCoreReadinessReport, getCoreRecentEvents, getCoreSystemRuntime, getMcpProviders, updateMcpProviderState } from '../api/llm';
 import { pipelinesApi } from '../api/pipelines';
-import type { CoreCheck, CoreRecentEvent, McpProviderStatus, StepbitCoreStatus } from '../types';
+import type { CoreCheck, CoreRecentEvent, StepbitCoreStatus } from '../types';
 import { cn } from '../utils/cn';
-import { MarkdownContent } from '../components/MarkdownContent';
+import { CapabilityInventoryPanel } from '../components/system/CapabilityInventoryPanel';
 
 export function System() {
   const [selectedProviderName, setSelectedProviderName] = useState<string>('');
@@ -266,34 +266,17 @@ export function System() {
       </div>
 
       <div className="glass rounded-xs p-4">
-        <SectionHeader icon={PlugZap} title="Peripheral Inventory" subtitle="Provider-level state exposed by the core MCP manager." />
-        {providersLoading ? (
-          <LoadingPane />
-        ) : !providers?.length ? (
-          <EmptyMessage message="No provider data available." />
-        ) : (
-          <div className="mt-4 space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-            {providers.map((provider) => (
-              <ProviderTile
-                key={provider.name}
-                provider={provider}
-                selected={selectedProvider?.name === provider.name}
-                onSelect={setSelectedProviderName}
-                isMutating={providerStateMutation.isPending && providerStateMutation.variables?.provider === provider.name}
-                onToggleExternal={(enabled) => providerStateMutation.mutate({ provider: provider.name, enabled })}
-              />
-            ))}
-            </div>
-            {selectedProvider && (
-              <ProviderDetailPanel
-                provider={selectedProvider}
-                providerDoc={selectedProviderDoc}
-                providerDocLoading={selectedProviderDocLoading}
-              />
-            )}
-          </div>
-        )}
+        <SectionHeader icon={PlugZap} title="Connected Capabilities" subtitle="What this AI can use right now, and how each provider is enabled." />
+        <CapabilityInventoryPanel
+          providers={providers}
+          loading={providersLoading}
+          selectedProviderName={selectedProviderName}
+          onSelect={setSelectedProviderName}
+          selectedProviderDoc={selectedProviderDoc}
+          selectedProviderDocLoading={selectedProviderDocLoading}
+          isMutatingFor={(providerName) => providerStateMutation.isPending && providerStateMutation.variables?.provider === providerName}
+          onToggleExternal={(providerName, enabled) => providerStateMutation.mutate({ provider: providerName, enabled })}
+        />
       </div>
     </div>
   );
@@ -373,149 +356,6 @@ function HealthCheckTile({ check }: { check: CoreCheck }) {
           label={check.ok ? 'ok' : 'fail'}
           className={check.ok ? 'border-monokai-green/20 bg-monokai-green/15 text-monokai-green' : 'border-monokai-pink/20 bg-monokai-pink/15 text-monokai-pink'}
         />
-      </div>
-    </div>
-  );
-}
-
-function ProviderTile({
-  provider,
-  selected,
-  onSelect,
-  isMutating,
-  onToggleExternal,
-}: {
-  provider: McpProviderStatus;
-  selected: boolean;
-  onSelect: (name: string) => void;
-  isMutating: boolean;
-  onToggleExternal: (enabled: boolean) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(provider.name)}
-      className={cn(
-      'rounded-xs border p-3',
-      provider.status === 'installed'
-        ? 'border-monokai-green/20 bg-monokai-green/5'
-        : provider.status === 'failed'
-          ? 'border-monokai-pink/20 bg-monokai-pink/5'
-          : 'border-white/10 bg-white/5',
-      selected && 'ring-1 ring-monokai-aqua/40',
-    )}>
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-sm font-semibold text-gruv-light-1">{provider.name}</p>
-          <p className="mt-1 text-[11px] text-gruv-light-4">{provider.provider_type} • {provider.enabled ? 'enabled' : 'disabled'} • {provider.status}</p>
-        </div>
-        <StatusPill
-          label={provider.status}
-          className={
-            provider.status === 'installed'
-              ? 'border-monokai-green/20 bg-monokai-green/15 text-monokai-green'
-              : provider.status === 'failed'
-                ? 'border-monokai-pink/20 bg-monokai-pink/15 text-monokai-pink'
-                : 'border-white/10 bg-white/5 text-gruv-light-3'
-          }
-        />
-      </div>
-
-      {provider.provider_type === 'external' && (
-        <div className="mt-3 flex justify-end">
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onToggleExternal(!provider.enabled);
-            }}
-            disabled={isMutating}
-            className={cn(
-              'rounded-xs border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors',
-              provider.enabled
-                ? 'border-monokai-orange/30 bg-monokai-orange/10 text-monokai-orange hover:bg-monokai-orange/15'
-                : 'border-monokai-green/30 bg-monokai-green/10 text-monokai-green hover:bg-monokai-green/15',
-              isMutating && 'cursor-wait opacity-70',
-            )}
-          >
-            {isMutating ? 'Updating…' : provider.enabled ? 'Disable Plugin' : 'Enable Plugin'}
-          </button>
-        </div>
-      )}
-
-      {provider.reason && <p className="mt-3 text-xs text-gruv-light-3 whitespace-pre-wrap">{provider.reason}</p>}
-
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        {provider.capabilities.map((capability) => (
-          <StatusPill key={capability} label={capability} className="border-monokai-aqua/20 bg-monokai-aqua/10 text-monokai-aqua" />
-        ))}
-        {provider.installed_tools.map((tool) => (
-          <StatusPill key={tool} label={tool} className="border-monokai-orange/20 bg-monokai-orange/10 text-monokai-orange" />
-        ))}
-      </div>
-
-      {!!provider.planned_tools?.length && (
-        <div className="mt-3 border-t border-white/10 pt-3">
-          <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Planned Tools</p>
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {provider.planned_tools.map((tool) => (
-              <StatusPill key={tool} label={tool} className="border-monokai-purple/20 bg-monokai-purple/10 text-monokai-purple" />
-            ))}
-          </div>
-        </div>
-      )}
-    </button>
-  );
-}
-
-function ProviderDetailPanel({
-  provider,
-  providerDoc,
-  providerDocLoading,
-}: {
-  provider: McpProviderStatus;
-  providerDoc?: string;
-  providerDocLoading: boolean;
-}) {
-  return (
-    <div className="rounded-xs border border-monokai-aqua/20 bg-monokai-aqua/5 p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Selected Peripheral</p>
-          <h3 className="mt-2 text-base font-semibold text-gruv-light-1">{provider.name}</h3>
-          <p className="mt-1 text-xs text-gruv-light-4">
-            {provider.provider_type} • {provider.installed_tools.length} installed tool{provider.installed_tools.length === 1 ? '' : 's'} • {(provider.planned_tools?.length ?? 0)} planned
-          </p>
-        </div>
-        <StatusPill
-          label={provider.status}
-          className={
-            provider.status === 'installed'
-              ? 'border-monokai-green/20 bg-monokai-green/15 text-monokai-green'
-              : provider.status === 'failed'
-                ? 'border-monokai-pink/20 bg-monokai-pink/15 text-monokai-pink'
-                : 'border-white/10 bg-white/5 text-gruv-light-3'
-          }
-        />
-      </div>
-
-      <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
-        <ContextRow label="Installed Tools" value={provider.installed_tools.length > 0 ? provider.installed_tools.join(', ') : 'None'} />
-        <ContextRow label="Planned Tools" value={(provider.planned_tools?.length ?? 0) > 0 ? provider.planned_tools!.join(', ') : 'None'} />
-        <ContextRow label="Capabilities" value={provider.capabilities.length > 0 ? provider.capabilities.join(', ') : 'None'} />
-      </div>
-
-      <div className="mt-4 rounded-xs border border-white/10 bg-black/10 p-4">
-        <p className="text-[10px] uppercase tracking-[0.18em] text-gruv-light-4">Provider Guide</p>
-        {providerDocLoading ? (
-          <LoadingPane />
-        ) : providerDoc ? (
-          <div className="mt-3 max-h-[420px] overflow-y-auto pr-2">
-            <MarkdownContent content={providerDoc} />
-          </div>
-        ) : (
-          <EmptyMessage message="No provider guide available." />
-        )}
       </div>
     </div>
   );

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -184,11 +184,18 @@ export interface StepbitCoreStatus {
 export interface McpProviderStatus {
   id?: string;
   name: string;
+  title?: string;
+  summary?: string;
   provider_type: 'native' | 'external' | string;
   scope?: string;
   enabled: boolean;
   status: 'installed' | 'disabled' | 'failed' | string;
   reason?: string | null;
+  activation_kind?: string;
+  activation_target?: string | null;
+  activation_key?: string | null;
+  activation_hint?: string;
+  supports_toggle?: boolean;
   capabilities: string[];
   tool_count?: number;
   installed_tools: string[];


### PR DESCRIPTION
## Summary
- replace the oversized provider card grid with a compact capability inventory list
- surface human titles, short summaries, activation instructions, and config keys for each provider
- keep the detailed provider guide in the selected panel instead of making the main inventory a debugging surface

## Why
The existing System page inventory took too much space, used internal naming, and still did not tell the user how to enable or disable capabilities. This PR turns it into a control-plane surface that answers what each provider does and how to manage it.

## Testing
- `pnpm test -- --run src/pages/System.test.tsx`
- `pnpm build`