### PR TITLE
feat(chattools): add QuantLab local adapter MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Built with Go, DuckDB, React 19, and Vite, it is designed to sit in front of `st
 - DuckDB-backed local memory layer
 - SQL Explorer and database inspection flows
 - MCP tool discovery plus execution playground
+- QuantLab local adapter tool for running a local `quantlab` checkout through `main.py --json-request`
 - Skill library for reusable prompt assets
 
 ## Product Surfaces

--- a/docs/FEATURES_GUIDE.md
+++ b/docs/FEATURES_GUIDE.md
@@ -293,7 +293,23 @@ Execution History gives you a local audit trail of actions initiated from the ap
 
 ---
 
-## 17. Pluggable Infrastructure 🔌
+## 17. QuantLab Local Adapter (MVP) 🧰
+Stepbit includes a local adapter tool for invoking a QuantLab checkout from the app layer.
+
+### 🎯 What it does
+- resolves a local QuantLab interpreter when available
+- runs `main.py --json-request` with optional `--signal-file`
+- loads the canonical result from `report.json.machine_contract`
+- returns a normalized success/failure payload to Stepbit
+
+### 🧠 Practical Notes
+- the adapter is local-first and does not add distributed orchestration
+- the JSON request contract stays aligned with QuantLab's existing `run` and `sweep` request shapes
+- lifecycle visibility is preserved through the signal file when provided
+
+---
+
+## 18. Pluggable Infrastructure 🔌
 Stepbit is designed to work with or without `stepbit-core`. 
 - **Standalone**: All standard chat and search features work.
 - **Integrated**: Connect `stepbit-core` to unlock **Goal Mode**, the **Pipelines Hub**, **Scheduled Jobs**, **Triggers**, **Execution History**, **Reasoning Graphs**, and **Advanced MCP tools**.

--- a/internal/chattools/quantlab.go
+++ b/internal/chattools/quantlab.go
@@ -1,0 +1,424 @@
+package chattools
+
+import (
+	"bytes"
+	"context"
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const quantlabToolName = "quantlab_execute"
+
+type quantlabToolArgs struct {
+	Command          string         `json:"command"`
+	Params           map[string]any `json:"params"`
+	QuantLabRoot     string         `json:"quantlab_root,omitempty"`
+	PythonExecutable string         `json:"python_executable,omitempty"`
+	SignalFile       string         `json:"signal_file,omitempty"`
+	RequestID        string         `json:"request_id,omitempty"`
+	TimeoutSeconds   int            `json:"timeout_seconds,omitempty"`
+}
+
+type quantlabCommandRunner interface {
+	Run(ctx context.Context, command string, args []string, workdir string, env []string) (stdout string, stderr string, exitCode int, err error)
+}
+
+type execQuantLabRunner struct{}
+
+func (r *execQuantLabRunner) Run(
+	ctx context.Context,
+	command string,
+	args []string,
+	workdir string,
+	env []string,
+) (stdout string, stderr string, exitCode int, err error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = workdir
+	cmd.Env = env
+
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	runErr := cmd.Run()
+	if runErr != nil {
+		exitCode = -1
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return stdoutBuf.String(), stderrBuf.String(), exitCode, runErr
+	}
+
+	return stdoutBuf.String(), stderrBuf.String(), 0, nil
+}
+
+type QuantLabTool struct {
+	runner quantlabCommandRunner
+}
+
+func NewQuantLabTool() *QuantLabTool {
+	return newQuantLabToolWithRunner(&execQuantLabRunner{})
+}
+
+func newQuantLabToolWithRunner(runner quantlabCommandRunner) *QuantLabTool {
+	if runner == nil {
+		runner = &execQuantLabRunner{}
+	}
+	return &QuantLabTool{runner: runner}
+}
+
+func (t *QuantLabTool) Definition() ToolDefinition {
+	return ToolDefinition{
+		Name:        quantlabToolName,
+		Description: "Invoke a local QuantLab checkout via main.py --json-request and return canonical execution artifacts and machine_contract data.",
+		Parameters:  `{"type":"object","properties":{"command":{"type":"string","enum":["run","sweep"],"description":"QuantLab CLI command to invoke."},"params":{"type":"object","description":"QuantLab JSON-request params passed through to the CLI."},"quantlab_root":{"type":"string","description":"Optional path to the local QuantLab checkout."},"python_executable":{"type":"string","description":"Optional explicit Python interpreter to use."},"signal_file":{"type":"string","description":"Optional lifecycle signal file to pass through to QuantLab."},"request_id":{"type":"string","description":"Optional request id forwarded to QuantLab."},"timeout_seconds":{"type":"integer","minimum":1,"description":"Optional process timeout in seconds."}},"required":["command","params"]}`,
+	}
+}
+
+func (t *QuantLabTool) Call(ctx context.Context, arguments string, sessionID uuid.UUID, store ToolResultStore) (string, error) {
+	var args quantlabToolArgs
+	if err := stdjson.Unmarshal([]byte(arguments), &args); err != nil {
+		return "", fmt.Errorf("error parsing arguments: %w", err)
+	}
+
+	command := strings.TrimSpace(strings.ToLower(args.Command))
+	if command != "run" && command != "sweep" {
+		return "", fmt.Errorf("unsupported command %q: valid commands are run and sweep", args.Command)
+	}
+
+	params := args.Params
+	if params == nil {
+		params = map[string]any{}
+	}
+
+	quantlabRoot, err := resolveQuantLabRoot(args.QuantLabRoot)
+	if err != nil {
+		return "", err
+	}
+
+	pythonExecutable, err := resolveQuantLabPythonExecutable(quantlabRoot, args.PythonExecutable)
+	if err != nil {
+		return "", err
+	}
+
+	signalFile := strings.TrimSpace(args.SignalFile)
+	if signalFile == "" {
+		tempFile, tempErr := os.CreateTemp("", "stepbit-quantlab-*.jsonl")
+		if tempErr != nil {
+			return "", fmt.Errorf("prepare signal file: %w", tempErr)
+		}
+		signalFile = tempFile.Name()
+		_ = tempFile.Close()
+	}
+	if err := ensureEmptyFile(signalFile); err != nil {
+		return "", fmt.Errorf("prepare signal file: %w", err)
+	}
+
+	requestID := strings.TrimSpace(args.RequestID)
+	if requestID == "" {
+		requestID = "stepbit-" + uuid.NewString()
+	}
+
+	requestPayload := map[string]any{
+		"schema_version": "1.0",
+		"request_id":     requestID,
+		"command":        command,
+		"params":         params,
+	}
+	requestJSON, err := stdjson.Marshal(requestPayload)
+	if err != nil {
+		return "", fmt.Errorf("build json request payload: %w", err)
+	}
+
+	processCtx := ctx
+	var cancel context.CancelFunc
+	if args.TimeoutSeconds > 0 {
+		processCtx, cancel = context.WithTimeout(ctx, time.Duration(args.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
+
+	processArgs := []string{"main.py", "--json-request", string(requestJSON), "--signal-file", signalFile}
+	stdout, stderr, exitCode, runErr := t.runner.Run(
+		processCtx,
+		pythonExecutable,
+		processArgs,
+		quantlabRoot,
+		os.Environ(),
+	)
+
+	result := map[string]any{
+		"adapter":           "quantlab",
+		"status":            "failed",
+		"command":           command,
+		"request_id":        requestID,
+		"quantlab_root":     quantlabRoot,
+		"python_executable": pythonExecutable,
+		"signal_file":       signalFile,
+		"exit_code":         exitCode,
+		"process_error":     errorString(runErr),
+		"stdout":            strings.TrimSpace(stdout),
+		"stderr":            strings.TrimSpace(stderr),
+		"machine_contract":  nil,
+		"summary":           nil,
+		"run_id":            "",
+		"mode":              "",
+		"artifacts_path":    "",
+		"report_path":       "",
+		"signal_event":      nil,
+		"json_request":      requestPayload,
+	}
+
+	signalEvent, signalErr := readLatestSignalEvent(signalFile)
+	if signalErr == nil {
+		result["signal_event"] = signalEvent
+		mergeSignalEventIntoResult(result, signalEvent)
+	} else {
+		result["signal_error"] = signalErr.Error()
+	}
+
+	status := strings.ToLower(fmt.Sprint(result["status"]))
+	if status != "success" && status != "failed" && status != "aborted" {
+		result["status"] = "failed"
+	}
+
+	if result["status"] == "success" {
+		report, reportPath, reportErr := loadQuantLabReport(result)
+		if reportErr != nil {
+			result["status"] = "failed"
+			result["error"] = reportErr.Error()
+		} else {
+			result["report_path"] = reportPath
+			if machineContract, ok := report["machine_contract"]; ok {
+				result["machine_contract"] = machineContract
+			}
+			if summary, ok := report["summary"]; ok {
+				result["summary"] = summary
+			}
+		}
+	}
+
+	if result["status"] == "success" && result["machine_contract"] == nil {
+		result["status"] = "failed"
+		result["error"] = "missing machine_contract in report.json"
+	}
+
+	if strings.ToLower(fmt.Sprint(result["status"])) != "success" {
+		if signalErr == nil && signalEvent != nil && result["error"] == nil {
+			if message, ok := signalEvent["message"].(string); ok && strings.TrimSpace(message) != "" {
+				result["error"] = message
+			}
+		}
+		if result["error"] == nil && strings.TrimSpace(stderr) != "" {
+			result["error"] = strings.TrimSpace(stderr)
+		}
+		if result["error"] == nil && runErr != nil {
+			result["error"] = runErr.Error()
+		}
+	}
+
+	if store != nil {
+		if payload, marshalErr := stdjson.MarshalIndent(result, "", "  "); marshalErr == nil {
+			_, _ = store.InsertToolResult(&ToolResultRecord{
+				SessionID: sessionID,
+				SourceURL: fmt.Sprintf("quantlab://%s", command),
+				Content:   string(payload),
+			})
+		}
+	}
+
+	output, marshalErr := stdjson.MarshalIndent(result, "", "  ")
+	if marshalErr != nil {
+		return "", marshalErr
+	}
+
+	return string(output), nil
+}
+
+func resolveQuantLabRoot(explicit string) (string, error) {
+	candidates := []string{
+		strings.TrimSpace(explicit),
+		strings.TrimSpace(os.Getenv("STEPBIT_QUANTLAB_ROOT")),
+		strings.TrimSpace(os.Getenv("QUANTLAB_ROOT")),
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(cwd, "..", "quant_lab"),
+			filepath.Join(cwd, "..", "quantlab"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(candidate); err == nil {
+			if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+				if _, mainErr := os.Stat(filepath.Join(abs, "main.py")); mainErr == nil {
+					return filepath.Clean(abs), nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("quantlab root not found; set STEPBIT_QUANTLAB_ROOT or pass quantlab_root")
+}
+
+func resolveQuantLabPythonExecutable(root, explicit string) (string, error) {
+	candidates := []string{
+		strings.TrimSpace(explicit),
+		strings.TrimSpace(os.Getenv("STEPBIT_QUANTLAB_PYTHON")),
+		strings.TrimSpace(os.Getenv("QUANTLAB_PYTHON")),
+	}
+
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates, filepath.Join(root, ".venv", "Scripts", "python.exe"))
+		candidates = append(candidates, filepath.Join(root, ".venv", "Scripts", "python"))
+	} else {
+		candidates = append(candidates, filepath.Join(root, ".venv", "bin", "python"))
+		candidates = append(candidates, filepath.Join(root, ".venv", "bin", "python3"))
+	}
+	candidates = append(candidates, "python")
+	candidates = append(candidates, "python3")
+
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if filepath.IsAbs(candidate) || strings.Contains(candidate, string(os.PathSeparator)) {
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate, nil
+			}
+			continue
+		}
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to resolve python executable for QuantLab")
+}
+
+func ensureEmptyFile(path string) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, []byte{}, 0o600)
+}
+
+func readLatestSignalEvent(signalFile string) (map[string]any, error) {
+	content, err := os.ReadFile(signalFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var latest map[string]any
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := stdjson.Unmarshal([]byte(line), &payload); err == nil {
+			latest = payload
+		}
+	}
+
+	if latest == nil {
+		return nil, fmt.Errorf("no valid signal events found in %s", signalFile)
+	}
+
+	return latest, nil
+}
+
+func mergeSignalEventIntoResult(result map[string]any, event map[string]any) {
+	if event == nil {
+		return
+	}
+
+	if status, ok := event["status"].(string); ok && strings.TrimSpace(status) != "" {
+		result["status"] = strings.ToLower(strings.TrimSpace(status))
+	}
+
+	for _, key := range []string{
+		"mode",
+		"run_id",
+		"artifacts_path",
+		"report_path",
+		"summary",
+		"request_id",
+		"runs_index_root",
+	} {
+		if value, ok := event[key]; ok && value != nil {
+			result[key] = value
+		}
+	}
+
+	if errorType, ok := event["error_type"].(string); ok && strings.TrimSpace(errorType) != "" {
+		result["error_type"] = errorType
+	}
+	if message, ok := event["message"].(string); ok && strings.TrimSpace(message) != "" {
+		result["message"] = message
+	}
+}
+
+func loadQuantLabReport(result map[string]any) (map[string]any, string, error) {
+	candidates := make([]string, 0, 2)
+
+	if reportPath, _ := result["report_path"].(string); strings.TrimSpace(reportPath) != "" {
+		candidates = append(candidates, reportPath)
+	}
+	if artifactsPath, _ := result["artifacts_path"].(string); strings.TrimSpace(artifactsPath) != "" {
+		candidates = append(candidates, filepath.Join(artifactsPath, "report.json"))
+	}
+
+	var lastErr error
+	for _, candidate := range candidates {
+		report, err := loadJSONFile(candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return report, candidate, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("report.json not found")
+	}
+	return nil, "", lastErr
+}
+
+func loadJSONFile(path string) (map[string]any, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload map[string]any
+	if err := stdjson.Unmarshal(content, &payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func errorString(err error) any {
+	if err == nil {
+		return nil
+	}
+	return err.Error()
+}

--- a/internal/chattools/quantlab_test.go
+++ b/internal/chattools/quantlab_test.go
@@ -1,0 +1,381 @@
+package chattools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type quantlabRunnerFunc func(ctx context.Context, command string, args []string, workdir string, env []string) (stdout string, stderr string, exitCode int, err error)
+
+func (f quantlabRunnerFunc) Run(ctx context.Context, command string, args []string, workdir string, env []string) (stdout string, stderr string, exitCode int, err error) {
+	return f(ctx, command, args, workdir, env)
+}
+
+type quantlabToolStore struct {
+	records []*ToolResultRecord
+}
+
+func (s *quantlabToolStore) InsertToolResult(result *ToolResultRecord) (*ToolResultRecord, error) {
+	s.records = append(s.records, result)
+	return result, nil
+}
+
+func (s *quantlabToolStore) GetToolResult(id int64) (*ToolResultRecord, error) {
+	return nil, os.ErrNotExist
+}
+
+func TestRegistryIncludesQuantLabTool(t *testing.T) {
+	registry := NewRegistry()
+	definitions := registry.Definitions()
+
+	found := false
+	for _, def := range definitions {
+		if def.Name == quantlabToolName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected registry to include %s", quantlabToolName)
+	}
+}
+
+func TestQuantLabToolCallRunReturnsCanonicalPayload(t *testing.T) {
+	root := t.TempDir()
+	prepareQuantLabCheckout(t, root)
+
+	store := &quantlabToolStore{}
+	tool := newQuantLabToolWithRunner(quantlabRunnerFunc(func(ctx context.Context, command string, args []string, workdir string, env []string) (string, string, int, error) {
+		if command != filepath.Join(root, ".venv", "Scripts", "python.exe") {
+			t.Fatalf("unexpected interpreter: %s", command)
+		}
+		if workdir != root {
+			t.Fatalf("unexpected workdir: %s", workdir)
+		}
+
+		request := decodeRequestPayload(t, args)
+		if got := request["command"]; got != "run" {
+			t.Fatalf("unexpected request command: %v", got)
+		}
+		params := request["params"].(map[string]any)
+		if got := params["ticker"]; got != "ETH-USD" {
+			t.Fatalf("unexpected request ticker: %v", got)
+		}
+
+		signalFile := extractFlagValue(t, args, "--signal-file")
+		runID := "run_local_001"
+		artifactsPath := filepath.Join(root, "outputs", "runs", runID)
+		if err := os.MkdirAll(artifactsPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeJSONFile(t, filepath.Join(artifactsPath, "report.json"), map[string]any{
+			"status": "success",
+			"summary": map[string]any{
+				"total_return": 0.12,
+			},
+			"machine_contract": map[string]any{
+				"contract_type": "quantlab.run.result",
+				"summary": map[string]any{
+					"total_return": 0.12,
+				},
+			},
+		})
+		writeSignalFile(t, signalFile, []map[string]any{
+			{
+				"event":          "SESSION_STARTED",
+				"status":         "running",
+				"request_id":     request["request_id"],
+				"mode":           "run",
+				"run_id":         runID,
+				"artifacts_path": artifactsPath,
+				"report_path":    filepath.Join(artifactsPath, "report.json"),
+			},
+			{
+				"event":          "SESSION_COMPLETED",
+				"status":         "success",
+				"request_id":     request["request_id"],
+				"mode":           "run",
+				"run_id":         runID,
+				"artifacts_path": artifactsPath,
+				"report_path":    filepath.Join(artifactsPath, "report.json"),
+				"summary": map[string]any{
+					"total_return": 0.12,
+				},
+			},
+		})
+
+		return "run completed", "", 0, nil
+	}))
+
+	output, err := tool.Call(context.Background(), buildQuantLabRequestJSON(t, map[string]any{
+		"command":       "run",
+		"quantlab_root": root,
+		"params": map[string]any{
+			"ticker":   "ETH-USD",
+			"start":    "2023-01-01",
+			"end":      "2023-01-10",
+			"interval": "1d",
+		},
+	}), uuid.New(), store)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("failed to decode tool output: %v\n%s", err, output)
+	}
+
+	if result["status"] != "success" {
+		t.Fatalf("expected success status, got %v", result["status"])
+	}
+	if result["command"] != "run" {
+		t.Fatalf("expected run command, got %v", result["command"])
+	}
+	if result["run_id"] != "run_local_001" {
+		t.Fatalf("unexpected run_id: %v", result["run_id"])
+	}
+	if result["artifacts_path"] != filepath.Join(root, "outputs", "runs", "run_local_001") {
+		t.Fatalf("unexpected artifacts_path: %v", result["artifacts_path"])
+	}
+
+	machineContract := result["machine_contract"].(map[string]any)
+	if machineContract["contract_type"] != "quantlab.run.result" {
+		t.Fatalf("unexpected machine_contract: %v", machineContract)
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("expected one stored tool result, got %d", len(store.records))
+	}
+	if !strings.Contains(store.records[0].Content, `"quantlab.run.result"`) {
+		t.Fatalf("stored tool result does not contain canonical machine contract")
+	}
+}
+
+func TestQuantLabToolCallSweepReturnsCanonicalPayload(t *testing.T) {
+	root := t.TempDir()
+	prepareQuantLabCheckout(t, root)
+
+	tool := newQuantLabToolWithRunner(quantlabRunnerFunc(func(ctx context.Context, command string, args []string, workdir string, env []string) (string, string, int, error) {
+		request := decodeRequestPayload(t, args)
+		if got := request["command"]; got != "sweep" {
+			t.Fatalf("unexpected request command: %v", got)
+		}
+		params := request["params"].(map[string]any)
+		if got := params["config_path"]; got != "configs/experiments/eth.yaml" {
+			t.Fatalf("unexpected config_path: %v", got)
+		}
+		if got := params["out_dir"]; got != "outputs/stepbit" {
+			t.Fatalf("unexpected out_dir: %v", got)
+		}
+
+		signalFile := extractFlagValue(t, args, "--signal-file")
+		runID := "sweep_local_001"
+		artifactsPath := filepath.Join(root, "outputs", "runs", runID)
+		if err := os.MkdirAll(artifactsPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeJSONFile(t, filepath.Join(artifactsPath, "report.json"), map[string]any{
+			"status": "success",
+			"summary": map[string]any{
+				"best_score": 0.88,
+			},
+			"machine_contract": map[string]any{
+				"contract_type": "quantlab.sweep.result",
+				"summary": map[string]any{
+					"best_score": 0.88,
+				},
+			},
+		})
+		writeSignalFile(t, signalFile, []map[string]any{
+			{
+				"event":          "SESSION_STARTED",
+				"status":         "running",
+				"request_id":     request["request_id"],
+				"mode":           "sweep",
+				"run_id":         runID,
+				"artifacts_path": artifactsPath,
+				"report_path":    filepath.Join(artifactsPath, "report.json"),
+			},
+			{
+				"event":          "SESSION_COMPLETED",
+				"status":         "success",
+				"request_id":     request["request_id"],
+				"mode":           "sweep",
+				"run_id":         runID,
+				"artifacts_path": artifactsPath,
+				"report_path":    filepath.Join(artifactsPath, "report.json"),
+				"summary": map[string]any{
+					"best_score": 0.88,
+				},
+			},
+		})
+
+		return "sweep completed", "", 0, nil
+	}))
+
+	output, err := tool.Call(context.Background(), buildQuantLabRequestJSON(t, map[string]any{
+		"command":       "sweep",
+		"quantlab_root": root,
+		"params": map[string]any{
+			"config_path": "configs/experiments/eth.yaml",
+			"out_dir":     "outputs/stepbit",
+		},
+	}), uuid.New(), nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("failed to decode tool output: %v\n%s", err, output)
+	}
+
+	if result["status"] != "success" {
+		t.Fatalf("expected success status, got %v", result["status"])
+	}
+	if result["command"] != "sweep" {
+		t.Fatalf("expected sweep command, got %v", result["command"])
+	}
+	if result["run_id"] != "sweep_local_001" {
+		t.Fatalf("unexpected run_id: %v", result["run_id"])
+	}
+
+	machineContract := result["machine_contract"].(map[string]any)
+	if machineContract["contract_type"] != "quantlab.sweep.result" {
+		t.Fatalf("unexpected machine_contract: %v", machineContract)
+	}
+}
+
+func TestQuantLabToolCallFailedRunReturnsDeterministicPayload(t *testing.T) {
+	root := t.TempDir()
+	prepareQuantLabCheckout(t, root)
+
+	tool := newQuantLabToolWithRunner(quantlabRunnerFunc(func(ctx context.Context, command string, args []string, workdir string, env []string) (string, string, int, error) {
+		request := decodeRequestPayload(t, args)
+		signalFile := extractFlagValue(t, args, "--signal-file")
+		writeSignalFile(t, signalFile, []map[string]any{
+			{
+				"event":      "SESSION_STARTED",
+				"status":     "running",
+				"request_id": request["request_id"],
+				"mode":       "run",
+			},
+			{
+				"event":      "SESSION_FAILED",
+				"status":     "failed",
+				"request_id": request["request_id"],
+				"mode":       "run",
+				"error_type": "ConfigError",
+				"message":    "missing config_path",
+			},
+		})
+
+		return "", "missing config_path", 1, context.DeadlineExceeded
+	}))
+
+	output, err := tool.Call(context.Background(), buildQuantLabRequestJSON(t, map[string]any{
+		"command":       "run",
+		"quantlab_root": root,
+		"params": map[string]any{
+			"ticker": "ETH-USD",
+		},
+	}), uuid.New(), nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("failed to decode tool output: %v\n%s", err, output)
+	}
+
+	if result["status"] != "failed" {
+		t.Fatalf("expected failed status, got %v", result["status"])
+	}
+	if result["error_type"] != "ConfigError" {
+		t.Fatalf("unexpected error_type: %v", result["error_type"])
+	}
+	if result["error"] != "missing config_path" {
+		t.Fatalf("unexpected error message: %v", result["error"])
+	}
+}
+
+func prepareQuantLabCheckout(t *testing.T, root string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(root, ".venv", "Scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.py"), []byte("# quantlab"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".venv", "Scripts", "python.exe"), []byte("python"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeRequestPayload(t *testing.T, args []string) map[string]any {
+	t.Helper()
+	payload := extractFlagValue(t, args, "--json-request")
+
+	var request map[string]any
+	if err := json.Unmarshal([]byte(payload), &request); err != nil {
+		t.Fatalf("failed to parse json request: %v", err)
+	}
+	return request
+}
+
+func extractFlagValue(t *testing.T, args []string, flag string) string {
+	t.Helper()
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	t.Fatalf("flag %s not found in args: %v", flag, args)
+	return ""
+}
+
+func writeSignalFile(t *testing.T, path string, events []map[string]any) {
+	t.Helper()
+
+	lines := make([]string, 0, len(events))
+	for _, event := range events {
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(data))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeJSONFile(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildQuantLabRequestJSON(t *testing.T, payload map[string]any) string {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/chattools/registry.go
+++ b/internal/chattools/registry.go
@@ -47,6 +47,7 @@ func NewRegistry() *Registry {
 	registry.Register(NewSearchTool())
 	registry.Register(NewReadFullContentTool())
 	registry.Register(NewReadURLTool())
+	registry.Register(NewQuantLabTool())
 	return registry
 }
 


### PR DESCRIPTION
## Summary

This PR adds a local QuantLab adapter tool to Stepbit so the app can invoke a QuantLab checkout via `main.py --json-request`, wait for completion, and normalize the result from canonical artifacts.

Changes included:
- add a `quantlab_execute` chat tool
- resolve a project-local QuantLab interpreter when available
- pass optional `--signal-file` for lifecycle visibility
- load canonical result data from `report.json.machine_contract`
- surface a normalized success/failure payload back to Stepbit
- register the tool in the default tool registry
- document the adapter in the README and features guide

## Why

This is the smallest useful adapter MVP for the Stepbit ↔ QuantLab boundary.

It keeps the integration local-first and avoids distributed orchestration while still giving Stepbit a deterministic way to invoke QuantLab and consume canonical outputs.

## Scope

This PR does not:
- add distributed execution
- add queueing or event-bus orchestration
- change QuantLab's execution contract
- add UI for the adapter

## Validation

Validated with:
- `go test ./internal/chattools`
- `go test ./...`

## Notes

- the adapter accepts `run` and `sweep` JSON-request shapes
- failure cases are returned as deterministic payloads instead of only process errors
- the result surface is intentionally centered on `report.json.machine_contract`

Closes #61
